### PR TITLE
Force redownload PepperFlash

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -54,7 +54,6 @@ gulp.task 'flash', async ->
   fs.ensureDirSync dir
   try
     yield fs.accessAsync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip"), fs.R_OK
-    yield fs.ensureFileSync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip")
     yield fs.removeSync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip")
   catch e
     log "Downloading flash plugin #{PLATFORM}"

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -54,6 +54,8 @@ gulp.task 'flash', async ->
   fs.ensureDirSync dir
   try
     yield fs.accessAsync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip"), fs.R_OK
+    yield fs.ensureFileSync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip")
+    yield fs.removeSync path.join(path.tempdir(), "flashplayer-#{PLATFORM}.zip")
   catch e
     log "Downloading flash plugin #{PLATFORM}"
     [response, body] = yield requestAsync


### PR DESCRIPTION
See here #188 
Force redownload the PepperFlash, even if there is the file of the same name
Win 10 x64 Pro works well.

#### May need to improve the coding style