### PR TITLE
Fix: task-panel align to right

### DIFF
--- a/views/components/main/assets/main.css
+++ b/views/components/main/assets/main.css
@@ -36,6 +36,7 @@
   width: 100%;
   display: flex;
   align-items: center;
+  text-align: left;
 }
 #MainView table tr td[colspan] {
   width: 100% !important;


### PR DESCRIPTION
之前
![screen shot 2015-08-11 at 1 24 32 pm](https://cloud.githubusercontent.com/assets/3337921/9190992/a0ee37a2-402e-11e5-9eb6-34d434b496d6.png)
之后
![screen shot 2015-08-11 at 1 37 07 pm](https://cloud.githubusercontent.com/assets/3337921/9190993/a61ec07a-402e-11e5-9c17-64764551ceb8.png)

原因：
`main.css` L33 `text-align: right;` 被应用到 task-panel 中