### PR TITLE
Add native menus on OSX and Fix #55

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,139 @@
     </poi-app>
   </poi-main>
   <script>
+    /* Add menu for OSX */
+    var remote = require('remote');
+    var Menu = remote.require('menu');
+    var webview = document.querySelector("kan-game webview");
+    var template = [
+      {
+        label: 'Poi',
+        submenu: [
+          {
+            label: '关于 Poi',
+            selector: 'orderFrontStandardAboutPanel:'
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: '服务',
+            submenu: []
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: '隐藏 Poi',
+            accelerator: 'Cmd+H',
+            selector: 'hide:'
+          },
+          {
+            label: '隐藏其他',
+            accelerator: 'Cmd+Shift+H',
+            selector: 'hideOtherApplications:'
+          },
+          {
+            label: '显示全部',
+            selector: 'unhideAllApplications:'
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: '退出',
+            accelerator: 'Cmd+Q',
+            selector: 'terminate:'
+          },
+        ]
+      },
+      {
+        label: '编辑',
+        submenu: [
+          {
+            label: '撤销',
+            accelerator: 'Cmd+Z',
+            selector: 'undo:'
+          },
+          {
+            label: '重做',
+            accelerator: 'Shift+Cmd+Z',
+            selector: 'redo:'
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: '剪切',
+            accelerator: 'Cmd+X',
+            selector: 'cut:'
+          },
+          {
+            label: '拷贝',
+            accelerator: 'Cmd+C',
+            selector: 'copy:'
+          },
+          {
+            label: '粘贴',
+            accelerator: 'Cmd+V',
+            selector: 'paste:'
+          },
+          {
+            label: '全选',
+            accelerator: 'Cmd+A',
+            selector: 'selectAll:'
+          }
+        ]
+      },
+      {
+        label: '显示',
+        submenu: [
+          {
+            label: '重新载入页面',
+            accelerator: 'Cmd+R',
+            click: function() { webview.reload(); }
+          },
+          {
+            label: '停止',
+            accelerator: 'Cmd+.',
+            click: function() { webview.stop(); }
+          },
+          {
+            label: '显示开发者工具',
+            accelerator: 'Alt+Cmd+I',
+            click: function() { webview.openDevTools(); }
+          },
+        ]
+      },
+      {
+        label: '窗口',
+        submenu: [
+          {
+            label: '最小化',
+            accelerator: 'Cmd+M',
+            selector: 'performMiniaturize:'
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: '前置全部窗口',
+            selector: 'arrangeInFront:'
+          }
+        ]
+      },
+      {
+        label: '帮助',
+        submenu: []
+      }
+    ];
+
+    menu = Menu.buildFromTemplate(template);
+
+    if (remote.process.platform == "darwin") {
+      Menu.setApplicationMenu(menu);
+    };
+
     require('./views/app');
     require('./views/update');
   </script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
   <title>poi</title>
   <link rel="stylesheet" id="bootstrap-css" href="./components/bootstrap/dist/css/bootstrap.css">
   <link rel="stylesheet" href="./components/font-awesome/css/font-awesome.min.css">


### PR DESCRIPTION
On OSX, the copy/paste shortcuts don't work because of the missing menu. According to the contributor's hint in https://github.com/atom/electron/issues/2402, I added the native menus in [index.html](../blob/master/index.html). It works well on v3.2.1.

I also added some other menu items and shortcuts for convenience, like minimize, reload and stop.

This commit shouldn't affect the Windows and Linux version.