### PR TITLE
修复 poi-control 在某些主题下高度错误

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -77,7 +77,6 @@ poi-control {
   height: 100%;
 }
 poi-control .btn-sm {
-  height: 28px;
   border-radius: 0px;
   border-width: 2px;
   padding: 2px 7px;


### PR DESCRIPTION
在不同主题中 `poi-info` 的高度不同，
如 darkly 中为 `30px`、paperdark 中为 `28px`。
然而在 `app.css` 指定了 `poi-control` 的高度为 `28px`，这并不合适。
删掉指定高度的 css 可以在不同主题下自动适应高度。