### PR TITLE
Limiting minimum SSL fallback version to TLS1.0

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -31,6 +31,7 @@ global.mainWindow = mainWindow = null
 listenPort = config.get 'poi.port', 12450
 app.commandLine.appendSwitch 'proxy-server', "127.0.0.1:#{listenPort}"
 app.commandLine.appendSwitch 'ignore-certificate-errors'
+app.commandLine.appendSwitch 'ssl-version-fallback-min', "tls1"
 
 # Pepper Flash
 if process.platform == 'linux'


### PR DESCRIPTION
Would fix the issue on some buggy http proxies that do not support SSL. Fixes #370
Require <a herf= "https://github.com/atom/electron/releases/tag/v0.33.2">Electron v0.33.2</a> or higher