### PR TITLE
Fixed: ship pane stuck under certain situation

### DIFF
--- a/views/components/main/parts/miniship-parts/minipanebody.cjsx
+++ b/views/components/main/parts/miniship-parts/minipanebody.cjsx
@@ -153,6 +153,7 @@ PaneBodyMini = React.createClass
   shouldComponentUpdate: (nextProps, nextState) ->
     nextProps.activeDeck is @props.deckIndex and nextProps.show
   componentWillReceiveProps: (nextProps) ->
+    {_ships} = window
     if @condDynamicUpdateFlag
       @condDynamicUpdateFlag = not @condDynamicUpdateFlag
     else


### PR DESCRIPTION
欧选的高压锅（

To reproduce:
1. 捞条新船
2. 切换到expanded ship view
3. 把新船编入舰队
4. 然后概览面板就挂啦
![e809c67a-ccc6-4a14-b93a-65e1dbf6e350](https://cloud.githubusercontent.com/assets/13615512/10370898/3f2b2c5e-6e24-11e5-890f-1879137050e4.png)

cc @KochiyaOcean 