### PR TITLE
Fix game-webview size

### DIFF
--- a/views/layout.horizontal.cjsx
+++ b/views/layout.horizontal.cjsx
@@ -60,7 +60,7 @@ adjustSize = ->
       document.documentElement.style.overflow = 'hidden';
     }
   """
-  adjustWebviewHeight "#{Math.floor(480 * factor) - 1}px"
+  adjustWebviewHeight "#{Math.floor(480 * factor)}px"
   $('kan-game #webview-wrapper')?.style?.width = "#{Math.floor(800 * factor)}px"
   $('kan-game').style.marginTop = "#{Math.max(0, (window.innerHeight - Math.floor(480 * factor - 1) - 30)) / 2.0}px"
   # Autoset plugin-dropdown height

--- a/views/layout.vertical.cjsx
+++ b/views/layout.vertical.cjsx
@@ -38,7 +38,7 @@ adjustSize = ->
       y: bound.y
       width: parseInt(newWidth + borderX)
       height: bound.height
-  adjustWebviewHeight "#{480.0 * factor - 1}px"
+  adjustWebviewHeight "#{480.0 * factor}px"
   $('kan-game #webview-wrapper')?.style?.width = "#{800 * factor}px"
   $('kan-game #webview-wrapper')?.style?.marginLeft = "#{Math.max(0, window.innerWidth - 800 * factor - 1) / 2}px"
   return if url != 'http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/' and !(url?.startsWith('http://osapi.dmm.com/gadgets/ifr'))


### PR DESCRIPTION
移除了自动适配时height的-1，win8.1 + electron 0.34.1 没出现多余的白边。
之前不加-1的时候会出现白边，现在好像已经没这个问题了？
需要更多平台的测试。