### PR TITLE
Updates for Electron v0.35.0

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -98,7 +98,7 @@ app.on 'ready', ->
       mainWindow.reloadArea = 'kan-game webview'
     else
       mainWindow.setMenu null
-  mainWindow.loadUrl "file://#{__dirname}/index.html"
+  mainWindow.loadURL "file://#{__dirname}/index.html"
   if process.env.DEBUG?
     mainWindow.openDevTools
       detach: true

--- a/docs/plugin-cn.md
+++ b/docs/plugin-cn.md
@@ -170,7 +170,7 @@ initialPluginWindow = ->
     y: config.get 'poi.window.y', 0
     width: 820
     height: 650
-  window.pluginWindow.loadUrl "file://#{__dirname}/index.html"
+  window.pluginWindow.loadURL "file://#{__dirname}/index.html"
 initialItemImprovementWindow()
 
 module.exports =

--- a/views/components/settings/parts/navigator-bar.cjsx
+++ b/views/components/settings/parts/navigator-bar.cjsx
@@ -31,7 +31,7 @@ NavigatorBar = React.createClass
   handleStopLoading: ->
     @setState
       navigateStatus: 0
-      navigateUrl: webview.getUrl()
+      navigateUrl: webview.getURL()
   handleFailLoad: ->
     @setState
       navigateStatus: -2

--- a/views/layout.cjsx
+++ b/views/layout.cjsx
@@ -57,6 +57,6 @@ document.addEventListener 'DOMContentLoaded', ->
       realClose: true
       navigatable: true
       'node-integration': false
-    exWindow.loadUrl e.url
+    exWindow.loadURL e.url
     exWindow.show()
     e.preventDefault()

--- a/views/layout.horizontal.cjsx
+++ b/views/layout.horizontal.cjsx
@@ -19,7 +19,7 @@ adjustSize = ->
   webview = $('kan-game webview')
   url = null
   try
-    url = webview?.getUrl?()
+    url = webview?.getURL?()
   catch e
     url = null
   # return if webview.isLoading()

--- a/views/layout.vertical.cjsx
+++ b/views/layout.vertical.cjsx
@@ -18,7 +18,7 @@ adjustSize = ->
   poiapp = document.getElementsByTagName('poi-app')[0]
   url = null
   try
-    url = webview?.getUrl?()
+    url = webview?.getURL?()
   catch e
     url = null
   factor = Math.ceil(window.innerWidth /  800.0 * 100) / 100.0


### PR DESCRIPTION
# DO NOT MERGE UNTIL ELECTRON IS UPGRADED TO V0.35.0 OR NEWER!

The latest Electron has deprecated The “Url” in API names.
https://github.com/atom/electron/releases/tag/v0.35.0

_**All the plugins should be updated as well, at the time this pr is merged.**_
