### PR TITLE
add an id for miniship when it displays as component of main tab

### DIFF
--- a/views/components/main/parts/miniship.cjsx
+++ b/views/components/main/parts/miniship.cjsx
@@ -174,7 +174,7 @@ module.exports =
       @interval = clearInterval @interval if @interval?
     render: ->
       <div style={height: '100%'} onDoubleClick={@toggle}>
-        <Panel bsStyle="default" style={minHeight: 322, height: 'calc(100% - 8px)'}>
+        <Panel id="ShipViewMini" bsStyle="default" style={minHeight: 322, height: 'calc(100% - 8px)'}>
           <link rel="stylesheet" href={join(relative(ROOT, __dirname), '..', 'assets', 'miniship.css')} />
           <div className="panel-row">
             <ButtonGroup bsSize="xsmall">


### PR DESCRIPTION
#600 
Currently the only way to locate the miniship panel when it displayes as component of main tab, is `#MiniShip > div > div:nth-child(1)`.This PR is to make it easy to differentiate the appearence of miniship panel whether it is expanded or not.

Below is the effect I want to realize:
![image](https://cloud.githubusercontent.com/assets/3816900/11722041/cd122e42-9fa1-11e5-8d8f-b5753822c6ba.png)

I'm not sure if the id name is in a poi-like style