### PR TITLE
Tentative plugin tab redesign for #706 

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -69,6 +69,15 @@ table {
 poi-app poi-nav-tabs .nav {
   display: flex;
 }
+#top-nav {
+  display: inherit;
+}
+#top-nav > li:nth-child(-n+3){
+  width:26%;
+}
+#top-nav > li:nth-child(n+4){
+  width:11%;
+}
 poi-app poi-nav-tabs .nav li {
   flex: 1;
   overflow: hidden;

--- a/views/single-tabarea.cjsx
+++ b/views/single-tabarea.cjsx
@@ -58,6 +58,7 @@ ControlledTabArea = React.createClass
   getInitialState: ->
     key: 0
   nowTime: 0
+  pluginKey: 0
   componentWillUpdate: (nextProps, nextState) ->
     @nowTime = (new Date()).getTime()
   componentDidUpdate: (prevProps, prevState) ->
@@ -68,6 +69,8 @@ ControlledTabArea = React.createClass
   handleSelectMenuItem: (e, key) ->
     e.preventDefault()
     @setState {key} if key isnt @state.key
+    pluginKey = key
+    @setState {pluginKey}
   handleSelectMainView: ->
     event = new CustomEvent 'view.main.visible',
       bubbles: true
@@ -158,14 +161,15 @@ ControlledTabArea = React.createClass
         <NavItem key={1} eventKey={1} onSelect={@handleSelectShipView}>
           <span><FontAwesome key={0} name='server' />{window.i18n.main.__ ' Fleet'}</span>
         </NavItem>
-        <NavDropdown id='plugin-dropdown' key={-1} eventKey={-1} pullRight
-                     title=
-                     {
-                       if @state.key >= 2 and @state.key < 1000
-                         <span>{tabbedPlugins[@state.key - 2].displayName}</span>
-                       else
-                         <span><FontAwesome name='sitemap' />{__ ' Plugins'}</span>
-                     }>
+        <NavItem key={1001} eventKey={@state.pluginKey} onSelect={@handleSelect}>
+           {
+             if @state.pluginKey >= 2 and @state.pluginKey < 1000
+               <span>{tabbedPlugins[@state.pluginKey - 2].displayName}</span>
+             else
+               <span><FontAwesome name='sitemap' />{__ ' Plugins'}</span>
+           }
+        </NavItem>
+        <NavDropdown id='plugin-dropdown' key={-1} eventKey={-1} pullRight>
         {
           counter = 1
           plugins.map (plugin, index) =>

--- a/views/single-tabarea.cjsx
+++ b/views/single-tabarea.cjsx
@@ -68,9 +68,10 @@ ControlledTabArea = React.createClass
     @setState {key} if key isnt @state.key
   handleSelectMenuItem: (e, key) ->
     e.preventDefault()
-    @setState {key} if key isnt @state.key
-    pluginKey = key
-    @setState {pluginKey}
+    if key isnt @state.key
+      @setState {key}
+      pluginKey = key
+      @setState {pluginKey}
   handleSelectMainView: ->
     event = new CustomEvent 'view.main.visible',
       bubbles: true

--- a/views/single-tabarea.cjsx
+++ b/views/single-tabarea.cjsx
@@ -151,7 +151,7 @@ ControlledTabArea = React.createClass
     window.removeEventListener 'view.main.visible', @handleMiniShipChange
   render: ->
     <div>
-      <Nav bsStyle="tabs" activeKey={@state.key}>
+      <Nav bsStyle="tabs" activeKey={@state.key} id="top-nav">
         <NavItem key={0} eventKey={0} onSelect={@handleSelectMainView}>
           {mainview.displayName}
         </NavItem>


### PR DESCRIPTION
The plugin nav item is split into 2 sub items, one for selecting plugins, one for quickly return to last selected in-app plugin.

unsolved:
- settings component displayname
- key for new item

unknown:
- can this handler cover all cases?