### PR TITLE
Add Flash player loader

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -47,27 +47,8 @@ disableHA = config.get 'poi.disableHA', false
 if disableHA
   app.commandLine.appendSwitch 'disable-gpu'
 
-pepperFlashData =
-  linux:
-    filename: 'libpepflashplayer.so'
-    version: '20.0.0.248'
-  win32:
-    filename: 'pepflashplayer.dll'
-    version: '20.0.0.248'
-  darwin:
-    filename: 'PepperFlashPlayer.plugin'
-    version: '20.0.0.248'
-
-pepperFlashData = pepperFlashData[process.platform]
-innerFlashPath = path.join 'PepperFlash', process.platform, pepperFlashData.filename
-defaultFlashPath = path.join EXECROOT, innerFlashPath
-try
-  fs.accessSync defaultFlashPath
-  app.commandLine.appendSwitch 'ppapi-flash-path', defaultFlashPath
-  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version
-catch
-  app.commandLine.appendSwitch 'ppapi-flash-path', path.join(ROOT, innerFlashPath)
-  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version
+# Load Pepper Flash Player
+require('./lib/flash-loader').load()
 
 app.on 'window-all-closed', ->
   shortcut.unregister()

--- a/lib/cl.coffee
+++ b/lib/cl.coffee
@@ -1,6 +1,7 @@
 # Process Command Line Arguments
 {warn} = require './utils'
 Debug = require './debug'
+fl = require './flash-loader'
 
 # At this stage we only support a few flags,
 # so it's OK to process them one by one like this
@@ -57,6 +58,7 @@ process.argv.forEach (arg, idx) ->
     when preprocessArg(arg, idx) then return
     when checkShowVersion(arg) then return
     when parseDebugOptions(arg) then return
+    when fl.parseCLIArg(arg) then return
     # when parseWhateverOtherOptions(arg) then return
     else warn "Invalid argument (ignored): #{arg}"
 

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -100,7 +100,9 @@ parseCLIArg = (arg) ->
       if (m = reUseSpecialPath.exec value)?
         useFlashLoc = m[1]
       else
-        error "Unknown flash player location: #{value}"
+        error "Invalid flash player location: '#{value}'."
+        error "Use one of [@auto, @builtin, @chrome, @system], \
+          or the path to your '#{filename}'"
     else
       useFlashLoc = 'cli'
       CLIFlashPath = value
@@ -117,24 +119,30 @@ getPath = (loc = useFlashLoc) ->
       return flashPath
     when 'builtin'
       flashPath = getBuiltInFlashPath()
+      error 'Could not load built-in Pepper Flash Player'
     when 'chrome'
       flashPath = findChromeFlashPath()
+      error 'Could not load Chrome Pepper Flash Player'
     when 'system'
       flashPath = findSystemFlashPath()
+      error 'Could not load system Pepper Flash Player plug-in'
     when 'cli'
       if validatePath CLIFlashPath
         flashPath = CLIFlashPath
       else
-        error "Invalid path for flash player: \n#{CLIFlashPath}"
+        error "Invalid path to '#{filename}': \n#{CLIFlashPath}"
+  dbg.ex.flashLoader?.log 'Fall back to auto-detection'
   flashPath ?= getPath 'auto'
   flashPath
 
 load = ->
   flashPath = getPath()
-  dbg.ex.flashLoader?.assert validatePath(flashPath), 'No installed Pepper Flash Player found.'
-  dbg.ex.flashLoader?.log "Loading Pepper Flash Player from:"
-  dbg.ex.flashLoader?.log flashPath
-  app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
+  if flashPath?
+    dbg.ex.flashLoader?.log "Loading Pepper Flash Player from:"
+    dbg.ex.flashLoader?.log flashPath
+    app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
+  else
+    error 'No installed Pepper Flash Player found'
 
 
 exports.parseCLIArg = parseCLIArg

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -98,9 +98,9 @@ getPath = ->
 
 load = ->
   flashPath = getPath()
-  dbg.extra('flashLoader').assert validatePath(flashPath), 'Path to Pepper Flash Player is invalid.'
-  dbg.ex.flashLoader.log "Loading flash player from:"
-  dbg.ex.flashLoader.log flashPath
+  dbg.ex.flashLoader?.assert validatePath(flashPath), 'No installed Pepper Flash Player found.'
+  dbg.ex.flashLoader?.log "Loading Pepper Flash Player from:"
+  dbg.ex.flashLoader?.log flashPath
   app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
 
 

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -29,14 +29,19 @@ getNewerVersion = (ver1, ver2) ->
   for i in [1..4]
     continue if v1[i] == v2[i]
     return if parseInt(v1[i]) > parseInt(v2[i]) then ver1 else ver2
+
 findChromeFlashPath = ->
+  # Refer to: https://helpx.adobe.com/flash-player/kb/flash-player-google-chrome.html
   switch platform
     when 'darwin'
-      # "/Applications/Google Chrome.app/Contents/Versions/48.0.2564.109/Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin/Contents/Info.plist"
       try
+        # Usually there are 2 directories under the 'Versions' directory,
+        # all named after their respective Google Chrome version number.
+        # Find the newest version of Google Chrome
+        # and use its built-in Pepper Flash Player plugin.
         chromeVersionsDir = '/Applications/Google Chrome.app/Contents/Versions'
         chromeVersions = fs.readdirSync chromeVersionsDir
-        return '' if chromeVersions.length is 0
+        return '' if chromeVersions.length is 0 # Broken Chrome...
         chromeVer = chromeVersions.reduce getNewerVersion
         chromeFlashPath = join chromeVersionsDir, chromeVer,
           'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin'
@@ -51,7 +56,8 @@ getFlashVersion = (path) ->
   return '' if not validatePath path
   switch platform
     when 'darwin'
-      plistPath = join path, 'Contents/Info.plist'
+      # The version info is in the Info.plist inside PepperFlashPlayer.plugin
+      plistPath = join path, 'Contents', 'Info.plist'
       plistContent = fs.readFileSync(plistPath, 'utf8')
       match = /<key>CFBundleVersion<\/key>\s*<string>(\d+(?:\.\d+)*)<\/string>/.exec plistContent
       if match and match.length > 1 then match[1] else ''

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -137,8 +137,9 @@ load = ->
     dbg.ex.flashLoader?.log flashPath
     app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
 
+if process.type is 'browser'
+  exports.parseCLIArg = parseCLIArg
+  exports.loadFlashPlayer = load
 
-exports.parseCLIArg = parseCLIArg
-exports.loadFlashPlayer = load
 exports.getFlashPlayerVersion = getFlashVersion
 exports.getAllVersions = getAllVersions

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -103,6 +103,13 @@ parseCLIArg = (arg) ->
   m?
 
 getPath = (loc = 'auto') ->
+  # The order of detecting Pepper Flash Player:
+  # 1. If '@builtin'/'@chrome'/'@system'/[a file path] is passed from CLI,
+  #    try to find flash player from the specified location.
+  # 2. If 1 failed, or '@auto' or nothing is passed from CLI (i.e., auto-detection),
+  #    try to find built-in flash player.
+  # 3. If 2 failed, try to find Google Chrome integrated flash player.
+  # 4. If 3 failed, try to find globally installed flash player.
   switch loc
     when 'auto'
       flashPath = getBuiltInFlashPath()
@@ -136,6 +143,10 @@ load = ->
     dbg.ex.flashLoader?.log "Loading Pepper Flash Player from:"
     dbg.ex.flashLoader?.log flashPath
     app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
+    # Note: the 'ppapi-flash-version' switch is used by Google Chrome to decide
+    # which flash player to load (it'll choose the newest one), and dioplay in
+    # the 'chrome://version', 'chrome://plugins', 'chrome://flash' pages.
+    # But it's useless here, so we just ignore it.
 
 if process.type is 'browser'
   exports.parseCLIArg = parseCLIArg

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -102,11 +102,8 @@ parseCLIArg = (arg) ->
       else
         error "Unknown flash player location: #{value}"
     else
-      if validatePath value
-        useFlashLoc = 'cli'
-        CLIFlashPath = value
-      else
-        error "Invalid flash player path:\n#{value}"
+      useFlashLoc = 'cli'
+      CLIFlashPath = value
     true
   else
     false
@@ -125,7 +122,10 @@ getPath = (loc = useFlashLoc) ->
     when 'system'
       flashPath = findSystemFlashPath()
     when 'cli'
-      flashPath = CLIFlashPath
+      if validatePath CLIFlashPath
+        flashPath = CLIFlashPath
+      else
+        error "Invalid path for flash player: \n#{CLIFlashPath}"
   flashPath ?= getPath 'auto'
   flashPath
 

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -1,22 +1,18 @@
+{app} = require 'electron'
+path = require 'path-extra'
+fs = require 'fs-extra'
 
-pepperFlashData =
-  linux:
-    filename: 'libpepflashplayer.so'
-    version: '20.0.0.248'
-  win32:
-    filename: 'pepflashplayer.dll'
-    version: '20.0.0.248'
-  darwin:
-    filename: 'PepperFlashPlayer.plugin'
-    version: '20.0.0.248'
-
-pepperFlashData = pepperFlashData[process.platform]
-innerFlashPath = path.join 'PepperFlash', process.platform, pepperFlashData.filename
-defaultFlashPath = path.join EXECROOT, innerFlashPath
+platform = process.platform
+filename = switch platform
+  when 'darwin' then 'PepperFlashPlayer.plugin'
+  when 'linux'  then 'libpepflashplayer.so'
+  when 'win32'  then 'pepflashplayer.dll'
+innerPath = path.join 'PepperFlash', platform, filename
 try
-  fs.accessSync defaultFlashPath
-  app.commandLine.appendSwitch 'ppapi-flash-path', defaultFlashPath
-  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version
+  flashPath = path.join EXECROOT, innerPath
+  fs.accessSync flashPath
 catch
-  app.commandLine.appendSwitch 'ppapi-flash-path', path.join(ROOT, innerFlashPath)
-  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version
+  flashPath = path.join ROOT, innerPath
+dbg.extra('flashLoader').log "Loading flash player from:"
+dbg.extra('flashLoader').log flashPath
+app.commandLine.appendSwitch 'ppapi-flash-path', flashPath

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -52,22 +52,6 @@ findChromeFlashPath = ->
         chromeFlashPath
       catch
         null
-    when 'win32'
-      chromeInstallDirs = [
-        join(app.getPath('appData'), 'Local')
-        'C:\\Program Files (x86)'
-        'C:\\Program Files'
-      ]
-      for chromeDir in chromeInstallDirs
-        chromeVersionsDir = join chromeDir, 'Google', 'Chrome', 'Application'
-        try
-          chromeVersions = fs.readdirSync chromeVersionsDir
-          if chromeVersions.length > 0
-            chromeVer = chromeVersions.reduce getNewerVersion
-            chromeFlashPath = join chromeVersionsDir, chromeVer, 'PepperFlash', FILENAME
-            fs.accessSync chromeFlashPath
-            return chromeFlashPath
-      null
     else null
 
 findSystemFlashPath = ->

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -47,22 +47,27 @@ findChromeFlashPath = ->
         return null if chromeVersions.length is 0 # Broken Chrome...
         chromeVer = chromeVersions.reduce getNewerVersion
         chromeFlashPath = join chromeVersionsDir, chromeVer,
-          'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin'
+          'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash', FILENAME
         fs.accessSync chromeFlashPath
         chromeFlashPath
       catch
         null
     when 'win32'
-      try
-        chromeVersionsDir = join app.getPath('appData'), 'Local', 'Google', 'Chrome', 'Application'
-        chromeVersions = fs.readdirSync chromeVersionsDir
-        return null if chromeVersions.length is 0 # Broken Chrome...
-        chromeVer = chromeVersions.reduce getNewerVersion
-        chromeFlashPath = join chromeVersionsDir, chromeVer, 'PepperFlash', FILENAME
-        fs.accessSync chromeFlashPath
-        chromeFlashPath
-      catch
-        null
+      chromeInstallDirs = [
+        join(app.getPath('appData'), 'Local')
+        'C:\\Program Files (x86)'
+        'C:\\Program Files'
+      ]
+      for chromeDir in chromeInstallDirs
+        chromeVersionsDir = join chromeDir, 'Google', 'Chrome', 'Application'
+        try
+          chromeVersions = fs.readdirSync chromeVersionsDir
+          if chromeVersions.length > 0
+            chromeVer = chromeVersions.reduce getNewerVersion
+            chromeFlashPath = join chromeVersionsDir, chromeVer, 'PepperFlash', FILENAME
+            fs.accessSync chromeFlashPath
+            return chromeFlashPath
+      null
     else null
 
 findSystemFlashPath = ->

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -9,10 +9,10 @@ filename = switch platform
   when 'win32'  then 'pepflashplayer.dll'
 innerPath = join 'PepperFlash', platform, filename
 
-validatePath = (p) ->
-  return false if typeof p isnt 'string' or not p.endsWith filename
+validatePath = (path) ->
+  return false if typeof path isnt 'string' or not path.endsWith filename
   try
-    fs.accessSync p
+    fs.accessSync path
   catch
     return false
   true
@@ -47,6 +47,17 @@ findChromeFlashPath = ->
     when 'linux' then ''  # TODO
     when 'win32' then ''  # TODO
 
+getFlashVersion = (path) ->
+  return '' if not validatePath path
+  switch platform
+    when 'darwin'
+      plistPath = join path, 'Contents/Info.plist'
+      plistContent = fs.readFileSync(plistPath, 'utf8')
+      match = /<key>CFBundleVersion<\/key>\s*<string>(\d+(?:\.\d+)*)<\/string>/.exec plistContent
+      if match and match.length > 1 then match[1] else ''
+    when 'linux' then ''  # TODO
+    when 'win32' then ''  # TODO
+
 parseCLIArg = (arg) ->
   # --flash=useChrome
   # --flash-path=/Applications/Google\ Chrome.app/Contents/Versions/48.0.2564.109/Google\ Chrome\ Framework.framework/Internet\ Plug-Ins/PepperFlash/PepperFlashPlayer.plugin
@@ -65,5 +76,5 @@ load = ->
 
 
 exports.parseCLIArg = ->
-exports.getFlashPlayerVersion = (flashPlayerPath) ->
+exports.getFlashPlayerVersion = getFlashVersion
 exports.loadFlashPlayer = load

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -91,9 +91,9 @@ parseCLIArg = (arg) ->
   # --flash-path=/Applications/Google\ Chrome.app/Contents/Versions/48.0.2564.109/Google\ Chrome\ Framework.framework/Internet\ Plug-Ins/PepperFlash/PepperFlashPlayer.plugin
 
 getPath = ->
-  flashPath = findChromeFlashPath()
+  flashPath = builtInPath
+  flashPath ?= findChromeFlashPath()
   flashPath ?= findSystemFlashPath()
-  flashPath ?= builtInPath
   flashPath
 
 load = ->

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -119,13 +119,13 @@ getPath = (loc = useFlashLoc) ->
       return flashPath
     when 'builtin'
       flashPath = getBuiltInFlashPath()
-      error 'Could not load built-in Pepper Flash Player'
+      error 'Could not load built-in Pepper Flash Player' if not flashPath?
     when 'chrome'
       flashPath = findChromeFlashPath()
-      error 'Could not load Chrome Pepper Flash Player'
+      error 'Could not load Chrome Pepper Flash Player' if not flashPath?
     when 'system'
       flashPath = findSystemFlashPath()
-      error 'Could not load system Pepper Flash Player plug-in'
+      error 'Could not load system Pepper Flash Player plug-in' if not flashPath?
     when 'cli'
       if validatePath CLIFlashPath
         flashPath = CLIFlashPath

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -52,6 +52,19 @@ findChromeFlashPath = ->
     when 'linux' then ''  # TODO
     when 'win32' then ''  # TODO
 
+findSystemFlashPath = ->
+  # Download/install from: https://get.adobe.com/flashplayer/otherversions/
+  switch platform
+    when 'darwin'
+      try
+        systemFlashPath = '/Library/Internet Plug-Ins/PepperFlashPlayer/PepperFlashPlayer.plugin'
+        fs.accessSync systemFlashPath
+        systemFlashPath
+      catch
+        ''
+    when 'linux' then ''  # TODO
+    when 'win32' then ''  # TODO
+
 getFlashVersion = (path) ->
   return '' if not validatePath path
   switch platform
@@ -69,13 +82,14 @@ parseCLIArg = (arg) ->
   # --flash-path=/Applications/Google\ Chrome.app/Contents/Versions/48.0.2564.109/Google\ Chrome\ Framework.framework/Internet\ Plug-Ins/PepperFlash/PepperFlashPlayer.plugin
 
 getPath = ->
-  chromeFlashPath = findChromeFlashPath()
-  return chromeFlashPath if validatePath chromeFlashPath
-  builtInPath
+  flashPath = findChromeFlashPath()
+  flashPath = findSystemFlashPath() if not flashPath
+  flashPath = builtInPath if not flashPath
+  flashPath
 
 load = ->
   flashPath = getPath()
-  dbg.extra('flashLoader').assert validatePath(flashPath), ''
+  dbg.extra('flashLoader').assert validatePath(flashPath), 'Path to Pepper Flash Player is invalid.'
   dbg.ex.flashLoader.log "Loading flash player from:"
   dbg.ex.flashLoader.log flashPath
   app.commandLine.appendSwitch 'ppapi-flash-path', flashPath

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -1,0 +1,22 @@
+
+pepperFlashData =
+  linux:
+    filename: 'libpepflashplayer.so'
+    version: '20.0.0.248'
+  win32:
+    filename: 'pepflashplayer.dll'
+    version: '20.0.0.248'
+  darwin:
+    filename: 'PepperFlashPlayer.plugin'
+    version: '20.0.0.248'
+
+pepperFlashData = pepperFlashData[process.platform]
+innerFlashPath = path.join 'PepperFlash', process.platform, pepperFlashData.filename
+defaultFlashPath = path.join EXECROOT, innerFlashPath
+try
+  fs.accessSync defaultFlashPath
+  app.commandLine.appendSwitch 'ppapi-flash-path', defaultFlashPath
+  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version
+catch
+  app.commandLine.appendSwitch 'ppapi-flash-path', path.join(ROOT, innerFlashPath)
+  app.commandLine.appendSwitch 'ppapi-flash-version', pepperFlashData.version

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -17,8 +17,10 @@ validatePath = (path) ->
     return false
   true
 
-builtInPath = join EXECROOT, innerPath if EXECROOT?
-builtInPath = join ROOT, innerPath if not validatePath builtInPath
+getBuiltInFlashPath = ->
+  builtInPath = join EXECROOT, innerPath if EXECROOT?
+  builtInPath = join ROOT, innerPath if not validatePath builtInPath
+  if validatePath builtInPath then builtInPath else null
 
 reVerNum = /(\d+)\.(\d+)\.(\d+)\.(\d+)/
 getNewerVersion = (ver1, ver2) ->
@@ -84,7 +86,7 @@ class FlashPlayerVersions
     @system = getFlashVersion systemFlashPath if systemFlashPath?
 
 getAllVersions = ->
-  new FlashPlayerVersions builtInPath, findChromeFlashPath(), findSystemFlashPath()
+  new FlashPlayerVersions getBuiltInFlashPath(), findChromeFlashPath(), findSystemFlashPath()
 
 parseCLIArg = (arg) ->
   # --flash=useChrome

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -77,6 +77,15 @@ getFlashVersion = (path) ->
     when 'linux' then ''  # TODO
     when 'win32' then ''  # TODO
 
+class FlashPlayerVersions
+
+getAllVersions = ->
+  out = new FlashPlayerVersions
+  out.chrome = getFlashVersion findChromeFlashPath()
+  out.system = getFlashVersion findSystemFlashPath()
+  out.builtin = getFlashVersion builtInPath
+  out
+
 parseCLIArg = (arg) ->
   # --flash=useChrome
   # --flash-path=/Applications/Google\ Chrome.app/Contents/Versions/48.0.2564.109/Google\ Chrome\ Framework.framework/Internet\ Plug-Ins/PepperFlash/PepperFlashPlayer.plugin
@@ -96,5 +105,6 @@ load = ->
 
 
 exports.parseCLIArg = ->
-exports.getFlashPlayerVersion = getFlashVersion
 exports.loadFlashPlayer = load
+exports.getFlashPlayerVersion = getFlashVersion
+exports.getAllVersions = getAllVersions

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -10,16 +10,25 @@ filename = switch platform
 innerPath = join 'PepperFlash', platform, filename
 
 validatePath = (p) ->
-  return false if not p.endsWith filename
+  return false if typeof p isnt 'string' or not p.endsWith filename
   try
     fs.accessSync p
   catch
     return false
   true
 
-builtInPath = join EXECROOT, innerPath
+builtInPath = join EXECROOT, innerPath if EXECROOT?
 builtInPath = join ROOT, innerPath if not validatePath builtInPath
 
+reVerNum = /(\d+)\.(\d+)\.(\d+)\.(\d+)/
+getNewerVersion = (ver1, ver2) ->
+  v1 = reVerNum.exec ver1
+  v2 = reVerNum.exec ver2
+  if not v1
+    return if v2 then ver2 else ''
+  for i in [1..4]
+    continue if v1[i] == v2[i]
+    return if parseInt(v1[i]) > parseInt(v2[i]) then ver1 else ver2
 findChromeFlashPath = ->
   switch platform
     when 'darwin'
@@ -28,7 +37,7 @@ findChromeFlashPath = ->
         chromeVersionsDir = '/Applications/Google Chrome.app/Contents/Versions'
         chromeVersions = fs.readdirSync chromeVersionsDir
         return '' if chromeVersions.length is 0
-        chromeVer = chromeVersions[1] # TODO
+        chromeVer = chromeVersions.reduce getNewerVersion
         chromeFlashPath = join chromeVersionsDir, chromeVer,
           'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin'
         fs.accessSync chromeFlashPath

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -92,25 +92,17 @@ getAllVersions = ->
 useFlashLoc = 'auto'
 CLIFlashPath = ''
 reCLIArg = /^--flash-player=(.+)$/i
-reUseSpecialPath = /^@(auto|builtin|chrome|system)$/i
 parseCLIArg = (arg) ->
   if (m = reCLIArg.exec arg)?
     value = m[1]
     if value.startsWith '@'
-      if (m = reUseSpecialPath.exec value)?
-        useFlashLoc = m[1]
-      else
-        error "Invalid flash player location: '#{value}'."
-        error "Use one of [@auto, @builtin, @chrome, @system], \
-          or the path to your '#{filename}'"
+      useFlashLoc = value.slice 1
     else
       useFlashLoc = 'cli'
       CLIFlashPath = value
-    true
-  else
-    false
+  m?
 
-getPath = (loc) ->
+getPath = (loc = 'auto') ->
   switch loc
     when 'auto'
       flashPath = getBuiltInFlashPath()
@@ -130,10 +122,12 @@ getPath = (loc) ->
     when 'cli'
       flashPath = CLIFlashPath if validatePath CLIFlashPath
       errMsg = "Invalid path to '#{filename}': \n#{CLIFlashPath}"
+    else
+      errMsg = "Invalid Pepper Flash Player location: '@#{loc}'."
   if not flashPath?
     error errMsg
     dbg.ex.flashLoader?.log 'Falling back to auto-detection'
-    flashPath = getPath 'auto'
+    flashPath = getPath()
   flashPath
 
 load = ->

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -52,8 +52,18 @@ findChromeFlashPath = ->
         chromeFlashPath
       catch
         null
-    when 'linux' then null  # TODO
-    when 'win32' then null  # TODO
+    when 'win32'
+      try
+        chromeVersionsDir = join app.getPath('appData'), 'Local', 'Google', 'Chrome', 'Application'
+        chromeVersions = fs.readdirSync chromeVersionsDir
+        return null if chromeVersions.length is 0 # Broken Chrome...
+        chromeVer = chromeVersions.reduce getNewerVersion
+        chromeFlashPath = join chromeVersionsDir, chromeVer, 'PepperFlash', FILENAME
+        fs.accessSync chromeFlashPath
+        chromeFlashPath
+      catch
+        null
+    else null
 
 findSystemFlashPath = ->
   # Download/install from: https://get.adobe.com/flashplayer/otherversions/
@@ -65,8 +75,7 @@ findSystemFlashPath = ->
         systemFlashPath
       catch
         null
-    when 'linux' then null  # TODO
-    when 'win32' then null  # TODO
+    else null
 
 getFlashVersion = (path) ->
   dbg.ex.flashLoader?.assert path, 'No flash player path passed in!'
@@ -78,8 +87,7 @@ getFlashVersion = (path) ->
       plistContent = fs.readFileSync(plistPath, 'utf8')
       match = /<key>CFBundleVersion<\/key>\s*<string>(\d+(?:\.\d+)*)<\/string>/.exec plistContent
       if match and match.length > 1 then match[1] else ''
-    when 'linux' then ''  # TODO
-    when 'win32' then ''  # TODO
+    else ''
 
 class FlashPlayerVersions
   constructor: (builtInFlashPath, chromeFlashPath, systemFlashPath) ->

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -79,9 +79,9 @@ getFlashVersion = (path) ->
 
 class FlashPlayerVersions
   constructor: (builtInFlashPath, chromeFlashPath, systemFlashPath) ->
-    @builtin = getFlashVersion builtInFlashPath
-    @chrome = getFlashVersion chromeFlashPath
-    @system = getFlashVersion systemFlashPath
+    @builtin = getFlashVersion builtInFlashPath if builtInFlashPath?
+    @chrome = getFlashVersion chromeFlashPath if chromeFlashPath?
+    @system = getFlashVersion systemFlashPath if systemFlashPath?
 
 getAllVersions = ->
   new FlashPlayerVersions builtInPath, findChromeFlashPath(), findSystemFlashPath()

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -1,17 +1,17 @@
 {app} = require 'electron'
 {join} = require 'path-extra'
 fs = require 'fs-extra'
-{warn, error} = require './utils'
+{error} = require './utils'
 
-platform = process.platform
-filename = switch platform
+PLATFORM = process.platform
+FILENAME = switch PLATFORM
   when 'darwin' then 'PepperFlashPlayer.plugin'
   when 'linux'  then 'libpepflashplayer.so'
   when 'win32'  then 'pepflashplayer.dll'
-innerPath = join 'PepperFlash', platform, filename
+INNER_PATH = join 'PepperFlash', PLATFORM, FILENAME
 
 validatePath = (path) ->
-  return false if typeof path isnt 'string' or not path.endsWith filename
+  return false if typeof path isnt 'string' or not path.endsWith FILENAME
   try
     fs.accessSync path
   catch
@@ -19,8 +19,8 @@ validatePath = (path) ->
   true
 
 getBuiltInFlashPath = ->
-  builtInPath = join EXECROOT, innerPath if EXECROOT?
-  builtInPath = join ROOT, innerPath if not validatePath builtInPath
+  builtInPath = join EXECROOT, INNER_PATH if EXECROOT?
+  builtInPath = join ROOT, INNER_PATH if not validatePath builtInPath
   if validatePath builtInPath then builtInPath else null
 
 reVerNum = /(\d+)\.(\d+)\.(\d+)\.(\d+)/
@@ -35,7 +35,7 @@ getNewerVersion = (ver1, ver2) ->
 
 findChromeFlashPath = ->
   # Refer to: https://helpx.adobe.com/flash-player/kb/flash-player-google-chrome.html
-  switch platform
+  switch PLATFORM
     when 'darwin'
       try
         # Usually there are 2 directories under the 'Versions' directory,
@@ -57,7 +57,7 @@ findChromeFlashPath = ->
 
 findSystemFlashPath = ->
   # Download/install from: https://get.adobe.com/flashplayer/otherversions/
-  switch platform
+  switch PLATFORM
     when 'darwin'
       try
         systemFlashPath = '/Library/Internet Plug-Ins/PepperFlashPlayer/PepperFlashPlayer.plugin'
@@ -70,7 +70,7 @@ findSystemFlashPath = ->
 
 getFlashVersion = (path) ->
   return '' if not validatePath path
-  switch platform
+  switch PLATFORM
     when 'darwin'
       # The version info is in the Info.plist inside PepperFlashPlayer.plugin
       plistPath = join path, 'Contents', 'Info.plist'
@@ -121,7 +121,7 @@ getPath = (loc = 'auto') ->
       errMsg = 'Could not load system Pepper Flash Player plug-in'
     when 'cli'
       flashPath = CLIFlashPath if validatePath CLIFlashPath
-      errMsg = "Invalid path to '#{filename}': \n#{CLIFlashPath}"
+      errMsg = "Invalid path to '#{FILENAME}': \n#{CLIFlashPath}"
     else
       errMsg = "Invalid Pepper Flash Player location: '@#{loc}'."
   if not flashPath?

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -110,39 +110,38 @@ parseCLIArg = (arg) ->
   else
     false
 
-getPath = (loc = useFlashLoc) ->
+getPath = (loc) ->
   switch loc
     when 'auto'
       flashPath = getBuiltInFlashPath()
       flashPath ?= findChromeFlashPath()
       flashPath ?= findSystemFlashPath()
+      error 'No installed Pepper Flash Player found' if not flashPath?
       return flashPath
     when 'builtin'
       flashPath = getBuiltInFlashPath()
-      error 'Could not load built-in Pepper Flash Player' if not flashPath?
+      errMsg = 'Could not load built-in Pepper Flash Player'
     when 'chrome'
       flashPath = findChromeFlashPath()
-      error 'Could not load Chrome Pepper Flash Player' if not flashPath?
+      errMsg = 'Could not load Chrome Pepper Flash Player'
     when 'system'
       flashPath = findSystemFlashPath()
-      error 'Could not load system Pepper Flash Player plug-in' if not flashPath?
+      errMsg = 'Could not load system Pepper Flash Player plug-in'
     when 'cli'
-      if validatePath CLIFlashPath
-        flashPath = CLIFlashPath
-      else
-        error "Invalid path to '#{filename}': \n#{CLIFlashPath}"
-  dbg.ex.flashLoader?.log 'Fall back to auto-detection'
-  flashPath ?= getPath 'auto'
+      flashPath = CLIFlashPath if validatePath CLIFlashPath
+      errMsg = "Invalid path to '#{filename}': \n#{CLIFlashPath}"
+  if not flashPath?
+    error errMsg
+    dbg.ex.flashLoader?.log 'Falling back to auto-detection'
+    flashPath = getPath 'auto'
   flashPath
 
 load = ->
-  flashPath = getPath()
+  flashPath = getPath useFlashLoc
   if flashPath?
     dbg.ex.flashLoader?.log "Loading Pepper Flash Player from:"
     dbg.ex.flashLoader?.log flashPath
     app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
-  else
-    error 'No installed Pepper Flash Player found'
 
 
 exports.parseCLIArg = parseCLIArg

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -69,6 +69,7 @@ findSystemFlashPath = ->
     when 'win32' then null  # TODO
 
 getFlashVersion = (path) ->
+  dbg.ex.flashLoader?.assert path, 'No flash player path passed in!'
   return '' if not validatePath path
   switch PLATFORM
     when 'darwin'
@@ -91,7 +92,7 @@ getAllVersions = ->
 
 useFlashLoc = 'auto'
 CLIFlashPath = ''
-reCLIArg = /^--flash-player=(.+)$/i
+reCLIArg = /^--flash=(.+)$/i
 parseCLIArg = (arg) ->
   if (m = reCLIArg.exec arg)?
     value = m[1]
@@ -110,7 +111,7 @@ getPath = (loc = 'auto') ->
   #    try to find built-in flash player.
   # 3. If 2 failed, try to find Google Chrome integrated flash player.
   # 4. If 3 failed, try to find globally installed flash player.
-  switch loc
+  switch loc.toLowerCase()
     when 'auto'
       flashPath = getBuiltInFlashPath()
       flashPath ?= findChromeFlashPath()
@@ -150,7 +151,7 @@ load = ->
 
 if process.type is 'browser'
   exports.parseCLIArg = parseCLIArg
-  exports.loadFlashPlayer = load
+  exports.load = load
 
-exports.getFlashPlayerVersion = getFlashVersion
+exports.getFlashVersion = getFlashVersion
 exports.getAllVersions = getAllVersions

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -78,13 +78,13 @@ getFlashVersion = (path) ->
     when 'win32' then ''  # TODO
 
 class FlashPlayerVersions
+  constructor: (builtInFlashPath, chromeFlashPath, systemFlashPath) ->
+    @builtin = getFlashVersion builtInFlashPath
+    @chrome = getFlashVersion chromeFlashPath
+    @system = getFlashVersion systemFlashPath
 
 getAllVersions = ->
-  out = new FlashPlayerVersions
-  out.chrome = getFlashVersion findChromeFlashPath()
-  out.system = getFlashVersion findSystemFlashPath()
-  out.builtin = getFlashVersion builtInPath
-  out
+  new FlashPlayerVersions builtInPath, findChromeFlashPath(), findSystemFlashPath()
 
 parseCLIArg = (arg) ->
   # --flash=useChrome

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -1,5 +1,5 @@
 {app} = require 'electron'
-path = require 'path-extra'
+{join} = require 'path-extra'
 fs = require 'fs-extra'
 
 platform = process.platform
@@ -7,12 +7,54 @@ filename = switch platform
   when 'darwin' then 'PepperFlashPlayer.plugin'
   when 'linux'  then 'libpepflashplayer.so'
   when 'win32'  then 'pepflashplayer.dll'
-innerPath = path.join 'PepperFlash', platform, filename
-try
-  flashPath = path.join EXECROOT, innerPath
-  fs.accessSync flashPath
-catch
-  flashPath = path.join ROOT, innerPath
-dbg.extra('flashLoader').log "Loading flash player from:"
-dbg.extra('flashLoader').log flashPath
-app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
+innerPath = join 'PepperFlash', platform, filename
+
+validatePath = (p) ->
+  return false if not p.endsWith filename
+  try
+    fs.accessSync p
+  catch
+    return false
+  true
+
+builtInPath = join EXECROOT, innerPath
+builtInPath = join ROOT, innerPath if not validatePath builtInPath
+
+findChromeFlashPath = ->
+  switch platform
+    when 'darwin'
+      # "/Applications/Google Chrome.app/Contents/Versions/48.0.2564.109/Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin/Contents/Info.plist"
+      try
+        chromeVersionsDir = '/Applications/Google Chrome.app/Contents/Versions'
+        chromeVersions = fs.readdirSync chromeVersionsDir
+        return '' if chromeVersions.length is 0
+        chromeVer = chromeVersions[1] # TODO
+        chromeFlashPath = join chromeVersionsDir, chromeVer,
+          'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin'
+        fs.accessSync chromeFlashPath
+        chromeFlashPath
+      catch
+        ''
+    when 'linux' then ''  # TODO
+    when 'win32' then ''  # TODO
+
+parseCLIArg = (arg) ->
+  # --flash=useChrome
+  # --flash-path=/Applications/Google\ Chrome.app/Contents/Versions/48.0.2564.109/Google\ Chrome\ Framework.framework/Internet\ Plug-Ins/PepperFlash/PepperFlashPlayer.plugin
+
+getPath = ->
+  chromeFlashPath = findChromeFlashPath()
+  return chromeFlashPath if validatePath chromeFlashPath
+  builtInPath
+
+load = ->
+  flashPath = getPath()
+  dbg.extra('flashLoader').assert validatePath(flashPath), ''
+  dbg.ex.flashLoader.log "Loading flash player from:"
+  dbg.ex.flashLoader.log flashPath
+  app.commandLine.appendSwitch 'ppapi-flash-path', flashPath
+
+
+exports.parseCLIArg = ->
+exports.getFlashPlayerVersion = (flashPlayerPath) ->
+exports.loadFlashPlayer = load

--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -41,16 +41,16 @@ findChromeFlashPath = ->
         # and use its built-in Pepper Flash Player plugin.
         chromeVersionsDir = '/Applications/Google Chrome.app/Contents/Versions'
         chromeVersions = fs.readdirSync chromeVersionsDir
-        return '' if chromeVersions.length is 0 # Broken Chrome...
+        return null if chromeVersions.length is 0 # Broken Chrome...
         chromeVer = chromeVersions.reduce getNewerVersion
         chromeFlashPath = join chromeVersionsDir, chromeVer,
           'Google Chrome Framework.framework/Internet Plug-Ins/PepperFlash/PepperFlashPlayer.plugin'
         fs.accessSync chromeFlashPath
         chromeFlashPath
       catch
-        ''
-    when 'linux' then ''  # TODO
-    when 'win32' then ''  # TODO
+        null
+    when 'linux' then null  # TODO
+    when 'win32' then null  # TODO
 
 findSystemFlashPath = ->
   # Download/install from: https://get.adobe.com/flashplayer/otherversions/
@@ -61,9 +61,9 @@ findSystemFlashPath = ->
         fs.accessSync systemFlashPath
         systemFlashPath
       catch
-        ''
-    when 'linux' then ''  # TODO
-    when 'win32' then ''  # TODO
+        null
+    when 'linux' then null  # TODO
+    when 'win32' then null  # TODO
 
 getFlashVersion = (path) ->
   return '' if not validatePath path
@@ -83,8 +83,8 @@ parseCLIArg = (arg) ->
 
 getPath = ->
   flashPath = findChromeFlashPath()
-  flashPath = findSystemFlashPath() if not flashPath
-  flashPath = builtInPath if not flashPath
+  flashPath ?= findSystemFlashPath()
+  flashPath ?= builtInPath
   flashPath
 
 load = ->


### PR DESCRIPTION
用法 —— CLI：
`--flash=location` , `location` 可以为 `@auto`/`@builtin`/`@chrome`/`@system` 或者flash player文件的路径
* `@auto` 的顺序为：有内置就用内置，没有内置就用chrome的，没装chrome就用系统的(可以从adobe网站安装)
* 其他几个选项会先尝试找指定的，找不到的话再按auto的顺序找。
* 显示debug信息在CLI加上 `--debug-extra=flashLoader`
* `@chrome`&`@system`现只有OS X有效，~~linux和win可以依葫芦画瓢。。~~
* ~~完成之后以后 release就不用捆绑 flash了~~