### PR TITLE
Add method for batch set config

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -50,6 +50,9 @@ module.exports =
       fs.writeFileSync configPath, CSON.stringify(config, null, 2)
     catch e
       warn e
+  batchSet: (opts) ->
+    for path, value of opts
+      @set(path, value)
   setDefault: (path, value) ->
     if !configCache[path]?
       path = path.split('.').filter (p) -> p != ''
@@ -70,3 +73,6 @@ module.exports =
           fs.writeFileSync configPath, CSON.stringify(config, null, 2)
         catch e
           warn e
+  batchSetDefault: (opts) ->
+    for path, value of opts
+      @setDefault(path, value)


### PR DESCRIPTION
每次 `config.set`、`config.setDefault` 都是一次跨进程的调用。
可以提供批量操作减少调用次数。

不过我没测试过 remote 调用的负担有多大。