### PR TITLE
Remove the 'invalid argument' warning

### DIFF
--- a/lib/cl.coffee
+++ b/lib/cl.coffee
@@ -58,7 +58,7 @@ process.argv.forEach (arg, idx) ->
     when checkShowVersion(arg) then return
     when parseDebugOptions(arg) then return
     # when parseWhateverOtherOptions(arg) then return
-    else warn "Invalid argument (ignored): #{arg}"
+    # else - unrecognized argument, just ignore.
 
 # Finish initialization of debug environment
 Debug.init()


### PR DESCRIPTION
It might be an arg for electron/node/chrome...
-> #922