### PR TITLE
Add FP without aircraft proficiency and remodel level bonus

### DIFF
--- a/i18n/main/en-US.json
+++ b/i18n/main/en-US.json
@@ -35,6 +35,7 @@
   "Fighter Power": "FP",
   "Minimum FP": "Minimum FP",
   "Maximum FP": "Maximum FP",
+  "Legacy FP": "Legacy FP",
   "LOS": "LOS",
   "2-5 fall formula": "2-5 fall formula",
   "2-5 old formula": "2-5 old formula",

--- a/i18n/main/ja-JP.json
+++ b/i18n/main/ja-JP.json
@@ -39,6 +39,7 @@
   "Fighter Power": "制空",
   "Minimum FP": "最小制空",
   "Maximum FP": "最大制空",
+  "Legacy FP": "無加成制空",
   "LOS": "索敵",
   "2-5 fall formula": "2-5式(秋)",
   "2-5 old formula": "2-5式(旧)",

--- a/i18n/main/ko-KR.json
+++ b/i18n/main/ko-KR.json
@@ -37,6 +37,7 @@
   "Fighter Power": "제공",
   "Minimum FP": "최소 제공",
   "Maximum FP": "최대 제공",
+  "Legacy FP": "Legacy FP",
   "LOS": "색적",
   "2-5 fall formula": "2-5 가을",
   "2-5 old formula": "2-5 구",

--- a/i18n/main/zh-CN.json
+++ b/i18n/main/zh-CN.json
@@ -39,6 +39,7 @@
   "Fighter Power": "制空",
   "Minimum FP": "最小制空",
   "Maximum FP": "最大制空",
+  "Legacy FP": "无加成制空",
   "LOS": "索敌",
   "2-5 fall formula": "2-5 秋式",
   "2-5 old formula": "2-5 旧式",

--- a/i18n/main/zh-TW.json
+++ b/i18n/main/zh-TW.json
@@ -39,6 +39,7 @@
   "Fighter Power": "制空",
   "Minimum FP": "最小制空",
   "Maximum FP": "最大制空",
+  "Legacy FP": "無加成制空",
   "LOS": "索敵",
   "2-5 fall formula": "2-5 秋式",
   "2-5 old formula": "2-5 舊式",

--- a/views/components/ship-parts/topalert.es
+++ b/views/components/ship-parts/topalert.es
@@ -163,7 +163,9 @@ export default connect(
           <span style={{flex: 1}}>
             <OverlayTrigger placement='bottom' overlay={
               <Tooltip id={`topalert-FP-fleet-${fleetId}`}>
-                <span>{__('Minimum FP')}: {tyku.min} {__('Maximum FP')}: {tyku.max}</span>
+              <div>{__('Minimum FP')}: {tyku.min}</div>
+              <div>{__('Maximum FP')}: {tyku.max}</div>
+              <div>{__('Legacy FP')}: {tyku.legacy}</div>
               </Tooltip>
             }>
               <span>{__('Fighter Power')}: {tyku.max}</span>

--- a/views/components/ship-parts/topalert.es
+++ b/views/components/ship-parts/topalert.es
@@ -163,9 +163,9 @@ export default connect(
           <span style={{flex: 1}}>
             <OverlayTrigger placement='bottom' overlay={
               <Tooltip id={`topalert-FP-fleet-${fleetId}`}>
-              <div>{__('Minimum FP')}: {tyku.min}</div>
-              <div>{__('Maximum FP')}: {tyku.max}</div>
-              <div>{__('Legacy FP')}: {tyku.legacy}</div>
+                <div>{__('Minimum FP')}: {tyku.min}</div>
+                <div>{__('Maximum FP')}: {tyku.max}</div>
+                <div>{__('Legacy FP')}: {tyku.legacy}</div>
               </Tooltip>
             }>
               <span>{__('Fighter Power')}: {tyku.max}</span>

--- a/views/utils/game-utils.es
+++ b/views/utils/game-utils.es
@@ -104,6 +104,7 @@ export function equipIsAircraft(equipIconId) {
 export function getTyku(equipsData) {
   let minTyku = 0
   let maxTyku = 0
+  let legacyTyku = 0
   for (let i = 0; i < equipsData.length; i++) {
     if (!equipsData[i]) {
       continue
@@ -125,24 +126,28 @@ export function getTyku(equipsData) {
         // 艦载機
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * 0.2)
         tempTyku += aircraftLevelBonus[$equip.api_type[3]][tempAlv]
+        legacyTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       } else if ($equip.api_type[3] == 10 && ($equip.api_type[2] == 11 || $equip.api_type[2] == 45)) {
         // 水上機
         tempTyku += Math.sqrt(onslot) * $equip.api_tyku
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
+        legacyTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       } else if ([39, 40].includes($equip.api_type[3])) {
         // 噴式機
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * 0.2)
         tempTyku += aircraftLevelBonus[$equip.api_type[3]][tempAlv]
+        legacyTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       }
     }
   }
   return {
+    legacy: legacyTyku,
     min: minTyku,
     max: maxTyku,
   }


### PR DESCRIPTION
With a cleaner commit history this time:innocent:
Implemented #1004 
![tyku](https://cloud.githubusercontent.com/assets/12995396/21518334/cbfa8b2c-ccb3-11e6-8254-b05002ddff51.png)
