### PR TITLE
update maphp when selecting event map rank

### DIFF
--- a/views/redux/info/maps.es
+++ b/views/redux/info/maps.es
@@ -13,8 +13,15 @@ export function reducer(state={}, {type, body, postBody}) {
   }
   case '@@Response/kcsapi/api_req_map/select_eventmap_rank': {
     const id = `${postBody.api_maparea_id}${postBody.api_map_no}`
-    return reduxSet(state,
-      [id, 'api_eventmap', 'api_selected_rank'], parseInt(postBody.api_rank))
+    return compareUpdate(state, {
+      [id]: {
+        api_eventmap: {
+          api_selected_rank: parseInt(postBody.api_rank),
+          api_max_maphp: parseInt(body.api_max_maphp),
+          api_now_maphp: parseInt(body.api_max_maphp),
+        },
+      },
+    }, 3)
   }
   case '@@Response/kcsapi/api_req_map/start': {
     const {api_eventmap} = body


### PR DESCRIPTION
Map HP update for event map rank changes happens in `@@Response/kcsapi/api_req_map/start`, but some plugins such as `where my fuels gone` may read the value before, resulting incorrect map hp records in the plugin
This patch adds another update directly with `@@Response/kcsapi/api_req_map/select_eventmap_rank`