### PR TITLE
Add safe mode feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,13 @@ if (config.get('poi.disableHA', false)) {
   app.disableHardwareAcceleration()
 }
 
+// check safe mode config
+if (config.get('poi.enterSafeMode', false)) {
+  console.warn('Entering SAFE MODE according to config.')
+  global.isSafeMode = true
+  config.set('poi.enterSafeMode')
+}
+
 // Add shortcut to start menu when os is windows
 app.setAppUserModelId('org.poooi.poi')
 if (process.platform === 'win32' && config.get('poi.createShortcut', true)) {

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -138,5 +138,5 @@
   "Display Final Stage Notification": "最終戦ヒントを表示する",
   "Safe Mode": "セーフモード",
   "Poi is running in safe mode, plugins are not enabled automatically.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。",
-  "Enter safe mode on next startup": "次回にセーフモードで起動する"
+  "Enter safe mode on next startup": "次回起動時にセーフモードにする"
 }

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -135,5 +135,7 @@
   "Flash Quality & Window Mode": "Flash 画質とウインドウモード",
   "Data version": "データバージョン",
   "Update data": "データを更新する",
-  "Display Final Stage Notification": "最終戦ヒントを表示する"
+  "Display Final Stage Notification": "最終戦ヒントを表示する",
+  "Safe Mode": "セーフモード",
+  "Poi is running in safe mode, plugins are not automatically enabled.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。"
 }

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -137,5 +137,6 @@
   "Update data": "データを更新する",
   "Display Final Stage Notification": "最終戦ヒントを表示する",
   "Safe Mode": "セーフモード",
-  "Poi is running in safe mode, plugins are not enabled automatically.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。",
+  "Enter safe mode on next startup": "次回にセーフモードで起動する"
 }

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -137,5 +137,5 @@
   "Update data": "データを更新する",
   "Display Final Stage Notification": "最終戦ヒントを表示する",
   "Safe Mode": "セーフモード",
-  "Poi is running in safe mode, plugins are not automatically enabled.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。"
 }

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -135,5 +135,7 @@
   "Flash Quality & Window Mode": "Flash 画质和窗口模式",
   "Data version": "数据版本",
   "Update data": "更新数据",
-  "Display Final Stage Notification": "显示最终战提示"
+  "Display Final Stage Notification": "显示最终战提示",
+  "Safe Mode": "安全模式",
+  "Poi is running in safe mode, plugins are not automatically enabled.": "Poi 运行在安全模式下，插件没有自动启用。"
 }

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -137,5 +137,5 @@
   "Update data": "更新数据",
   "Display Final Stage Notification": "显示最终战提示",
   "Safe Mode": "安全模式",
-  "Poi is running in safe mode, plugins are not automatically enabled.": "Poi 运行在安全模式下，插件没有自动启用。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 运行在安全模式下，插件没有自动启用。"
 }

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -137,5 +137,6 @@
   "Update data": "更新数据",
   "Display Final Stage Notification": "显示最终战提示",
   "Safe Mode": "安全模式",
-  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 运行在安全模式下，插件没有自动启用。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 运行在安全模式下，插件没有自动启用。",
+  "Enter safe mode on next startup": "下次启动进入安全模式"
 }

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -137,5 +137,5 @@
   "Update data": "更新資料",
   "Display Final Stage Notification": "顯示最終戰提示",
   "Safe Mode": "安全模式",
-  "Poi is running in safe mode, plugins are not automatically enabled.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。"
 }

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -137,5 +137,6 @@
   "Update data": "更新資料",
   "Display Final Stage Notification": "顯示最終戰提示",
   "Safe Mode": "安全模式",
-  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。"
+  "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。",
+  "Enter safe mode on next startup": "下次啓動進入安全模式"
 }

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -135,5 +135,7 @@
   "Flash Quality & Window Mode": "Flash 畫質與視窗模式",
   "Data version": "資料版本",
   "Update data": "更新資料",
-  "Display Final Stage Notification": "顯示最終戰提示"
+  "Display Final Stage Notification": "顯示最終戰提示",
+  "Safe Mode": "安全模式",
+  "Poi is running in safe mode, plugins are not automatically enabled.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。"
 }

--- a/lib/cl.es
+++ b/lib/cl.es
@@ -81,6 +81,7 @@ const reSafeMode = /^-(-safe|S)$/i
 const checkSafeMode = (arg) => {
   if (reSafeMode.test(arg)) {
     global.isSafeMode = true
+    console.warn('Entering SAFE MODE.')
     return true
   } else {
     return false

--- a/lib/cl.es
+++ b/lib/cl.es
@@ -76,12 +76,24 @@ const parseDebugOptions = (arg) => {
   return true
 }
 
+const reSafeMode = /^-(-safe|S)$/i
+
+const checkSafeMode = (arg) => {
+  if (reSafeMode.test(arg)) {
+    global.isSafeMode = true
+    return true
+  } else {
+    return false
+  }
+}
+
 // Process Command Line Arguments one by one
 process.argv.forEach((arg, idx) =>{
   switch (true) {
   case preprocessArg(arg, idx): return
   case checkShowVersion(arg): return
   case parseDebugOptions(arg): return
+  case checkSafeMode(arg): return
   // case parseWhateverOtherOptions(arg): return
   // else - unrecognized argument, just ignore.
   }

--- a/views/components/settings/parts/plugin-config.es
+++ b/views/components/settings/parts/plugin-config.es
@@ -629,7 +629,7 @@ const PluginConfig = connect((state, props) => ({
             <Col xs={12}>
               { window.isSafeMode && 
                 <Panel header={__('Safe Mode')} bsStyle='warning'>
-                  {__('Poi is running in safe mode, plugins are not automatically enabled.')}
+                  {__('Poi is running in safe mode, plugins are not enabled automatically.')}
                 </Panel>
               }
               <ButtonGroup bsSize='small' className='plugin-buttongroup'>

--- a/views/components/settings/parts/plugin-config.es
+++ b/views/components/settings/parts/plugin-config.es
@@ -627,6 +627,11 @@ const PluginConfig = connect((state, props) => ({
         <Grid className='correct-container'>
           <Row className='plugin-rowspace'>
             <Col xs={12}>
+              { window.isSafeMode && 
+                <Panel header={__('Safe Mode')} bsStyle='warning'>
+                  {__('Poi is running in safe mode, plugins are not automatically enabled.')}
+                </Panel>
+              }
               <ButtonGroup bsSize='small' className='plugin-buttongroup'>
                 <Button onClick={this.checkUpdate}
                         disabled={this.state.checkingUpdate}

--- a/views/components/settings/parts/poi-config.es
+++ b/views/components/settings/parts/poi-config.es
@@ -791,6 +791,10 @@ class PoiConfig extends Component {
               :
               null
             }
+            <CheckboxLabelConfig
+              label={__('Enter safe mode on next startup')}
+              configName="poi.enterSafeMode"
+              defaultVal={false} />
           </Grid>
         </div>
       </div>

--- a/views/create-store.es
+++ b/views/create-store.es
@@ -15,7 +15,9 @@ const cachePosition = '_storeCache'
 const targetPaths = ['const', 'info', 'fcd']
 const storeCache = (function() {
   try {
-    return JSON.parse(localStorage.getItem(cachePosition) || '{}')
+    // clears store when in safe mode
+    const item = !window.isSafeMode ? localStorage.getItem(cachePosition) : '{}'
+    return JSON.parse(item || '{}')
   } catch (e) {
     return {}
   }

--- a/views/env.es
+++ b/views/env.es
@@ -23,6 +23,7 @@ window.MODULE_PATH = remote.getGlobal('MODULE_PATH')
 window.appIcon = remote.getGlobal('appIcon')
 fs.ensureDirSync(window.PLUGIN_PATH)
 fs.ensureDirSync(path.join(window.PLUGIN_PATH, 'node_modules'))
+window.isSafeMode = remote.getGlobal('isSafeMode')
 
 // Add ROOT to `require` search path
 require('module').globalPaths.push(window.ROOT)

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -59,10 +59,11 @@ class PluginManager extends EventEmitter {
     this.getPlugins()
   }
   readPlugins() {
+    // window.isSafeMode = true
     const pluginPaths = glob.sync(this.getPluginPath('poi-plugin-*'))
     let plugins = pluginPaths.map((pluginPath) => {
       let plugin = readPlugin(pluginPath)
-      if (plugin.enabled) {
+      if (plugin.enabled && !window.isSafeMode) {
         plugin = enablePlugin(plugin)
       }
       return plugin

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -59,7 +59,6 @@ class PluginManager extends EventEmitter {
     this.getPlugins()
   }
   readPlugins() {
-    // window.isSafeMode = true
     const pluginPaths = glob.sync(this.getPluginPath('poi-plugin-*'))
     let plugins = pluginPaths.map((pluginPath) => {
       let plugin = readPlugin(pluginPath)


### PR DESCRIPTION
If provided in command line option `--safe` or `-S` or checked `enter safe mode on next startup` in config panel, poi will enter safe mode with all plugins not enabled, and the store will be clear. The config check will be reset.
A panel will display for plugin config panel in safe mode:
![image](https://cloud.githubusercontent.com/assets/3816900/23099639/db97c23a-f6a6-11e6-8823-7a8b0e65fc09.png)

closes #1233 