### PR TITLE
Doc/ Enhance English Style Guide

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,6 +1,6 @@
 # Code style guide
 
-The document introduces the style guide for codes submited to poi. Codes of good and coherent style is friendly to other contributors and yourself in the future. Please follow them.
+This document introduces the style guide for code submitted to poi. Good and coherent code style is friendly to other contributors and yourself in the future. Please follow them.
 
 ## Make eslint happy
 poi uses [eslint](http://eslint.org/) as code linter, and is bundled with `.eslintrc.js` conf file. Eslint is accessible through [command line](http://eslint.org/docs/user-guide/command-line-interface), or you may try editors with eslint extensions, e.g.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,30 +1,30 @@
 # Code style guide
 
-This document introduces the style guide for code submitted to poi. Good and coherent code style is friendly to other contributors and yourself in the future. Please follow them.
+This document is the style guide for poi. Good and coherent style is helpful to other contributors and yourself in the future. Please follow them.
 
-## Make eslint happy
-poi uses [eslint](http://eslint.org/) as code linter, and is bundled with `.eslintrc.js` conf file. Eslint is accessible through [command line](http://eslint.org/docs/user-guide/command-line-interface), or you may try editors with eslint extensions, e.g.
+## Make ESlint happy
+poi uses [ESlint](http://eslint.org/) as code linter, and is bundled with `.eslintrc.js` conf file. ESlint is accessible through [command line](http://eslint.org/docs/user-guide/command-line-interface), or you may try editors with ESlint extensions, e.g.
 + Sublime Text 3 + SublimeLinter + SublimeLinter-eslint
 + Atom + Linter
 + Visual Studio Code + ESlint
 
-You should avoid eslint errors, and leave as few warnings as you can; our rules, however, cannot be 100% perfect, so if you encounter errors that cannot be fixed, please provide the information in code comments or Pull Request.
+You should avoid ESlint errors, and leave as few warnings as you can. Our rules are not perfect, so if you encounter any ESLint errors that cannot be resolved, please provide details of the error in comments or Pull Request.
 
 ## Other styles
 ### Naming
-Game api's variable naming are snake_case (e.g. `api_mst_slotitems`), you're allow to use them, for your variable definition, however, [camelCase](https://en.wikipedia.org/wiki/Camel_case) naming is recommended, for example, `apiMstSlotitems`.
+Game api's style use snake_case (e.g. `api_mst_slotitems`). You are allowed to use them for your variable definition too. However, [camelCase](https://en.wikipedia.org/wiki/Camel_case) is recommended, for example, `apiMstSlotitems`.
 
 ``` javascript
 const {api_maparea_id, api_mapinfo_no} = postBody
 const mapId = `${api_maparea_id}${api_mapinfo_no}`
 ```
-Function naming rules are the same as variables.
+Function use the same naming rules as variables.
 
-for constants, use SNAKE_CASE: `MAX_RETRY`，`APPDATA_PATH`.
+For constants, use SNAKE_CASE: `MAX_RETRY`，`APPDATA_PATH`.
 
-For class or react element, use CamelCase: `FileWriter`，`ShipView`.
+For class or react element, use PascalCase: `FileWriter`，`ShipView`.
 
-Files are naming in snake-case, e.g. `file-writer.es`，`ship-view.es`
+For files use kebab-case: `file-writer.es`，`ship-view.es`
 
 ### import export
 if babel es6 is available, please use babel's `import` / `export` syntax:
@@ -34,7 +34,7 @@ import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 
 export const extendReducer = ...
 ```
-Please notice the space between variables and angle brackets.
+Please note the space between variables and curly braces.
 
 In some cases, however, `require` is inevitable:
 ``` javascript
@@ -44,8 +44,8 @@ const fs = Promise.promisifyAll(require('fs-extra'))
 
 ### Leave a blank line (EOL) at the end of file
 
-### Comments
-Feel free to leave comments where necessary.
+### Code Comments
+Please feel free to write comments in your code where necessary.
 
 ### JSX
 Indentation for JSX are also 2 spaces.


### PR DESCRIPTION
Oh my Kagami, thank you for these wonderful guides and documents!
I definitely appreciate your effort for such great work!

I happen to see there are a few errors in the English one and correct them as I look through. This pull request is in an attempt to make the document even better.
* Code should always be code in the sense of programming. [source](http://english.stackexchange.com/questions/20455/is-it-wrong-to-use-the-word-codes-in-a-programming-context)
* I change all esLint or eslint to ESLint since it brand itself as so? I excluded SublimeLinter-eslint due to their branding of the plugin is lowercase. 
* There are some other minor mistake corrections in this pull request such as spelling and grammar.