### PR TITLE
Adding a refresh button on control bar

### DIFF
--- a/i18n/others/en-US.json
+++ b/i18n/others/en-US.json
@@ -48,6 +48,12 @@
   "Armor": "Armor",
   "Luck": "Luck",
 
+  "RefreshGameDialogTip": {
+      "text1": "Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are ",
+      "b1": "without confirmation",
+      "text2": " use at your own risk."
+  },
+
   "doyouknow-prefix": "#Tips# ",
   "doyouknow-contents": [
     "We frequently introduce new features in \"Tips\". You may disable it in settings though",

--- a/i18n/others/en-US.json
+++ b/i18n/others/en-US.json
@@ -51,7 +51,7 @@
   "RefreshGameDialogTip": {
       "text1": "Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are ",
       "b1": "without confirmation",
-      "text2": " use at your own risk."
+      "text2": ", use at your own risk."
   },
 
   "doyouknow-prefix": "#Tips# ",

--- a/i18n/others/ja-JP.json
+++ b/i18n/others/ja-JP.json
@@ -50,6 +50,8 @@
   "Armor": "装甲",
   "Luck": "運",
 
+  "RefreshGameDialogTip": false,
+
   "Resupply cost %d bauxite": "ボーキサイトを%d消費した",
 
   "doyouknow-prefix": "ヒント：",

--- a/i18n/others/ko-KR.json
+++ b/i18n/others/ko-KR.json
@@ -47,6 +47,8 @@
   "Armor": "장갑",
   "Luck": "운",
 
+  "RefreshGameDialogTip": false,
+
   "doyouknow-prefix": "[TIP] ",
   "doyouknow-contents": [
     "TIP은 설정에서 비활성화 할 수 있습니다.",

--- a/i18n/others/zh-CN.json
+++ b/i18n/others/zh-CN.json
@@ -57,7 +57,11 @@
   "Are you sure to refresh the game?": "确定要刷新游戏吗？",
   "Refresh page": "刷新游戏页面",
   "Reload Flash": "重新载入Flash",
-  "Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.": "提示：右键单击此按钮可重新载入Flash，按住Shift同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都<b>不会弹出该确认对话框</b>，请自担使用风险。",
+  "RefreshGameDialogTip": {
+      "text1": "提示：右键单击此按钮可重新载入Flash，按住Shift同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都",
+      "b1": "不会弹出该确认对话框",
+      "text2": "请自担使用风险。"
+  },
   "\"Refresh page\" is the same as pressing F5.": "“刷新游戏页面”与在页面上按F5效果相同。",
   "\"Reload Flash\" reloads only the Flash part, this is usually faster but could result in catbomb.": "“重新载入Flash”只重新载入Flash部分，一般更快，但可能会导致网络异常错误。",
 

--- a/i18n/others/zh-CN.json
+++ b/i18n/others/zh-CN.json
@@ -57,7 +57,7 @@
   "Are you sure to refresh the game?": "确定要刷新游戏吗？",
   "Refresh page": "刷新游戏页面",
   "Reload Flash": "重新载入Flash",
-  "Tip: Right clicking on this button reloads Flash and Left clicking with Alt key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.": "提示：右键单击此按钮可重新载入Flash，按住Alt同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都<b>不会弹出该确认对话框</b>，请自担使用风险。",
+  "Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.": "提示：右键单击此按钮可重新载入Flash，按住Shift同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都<b>不会弹出该确认对话框</b>，请自担使用风险。",
   "\"Refresh page\" is the same as pressing F5.": "“刷新游戏页面”与在页面上按F5效果相同。",
   "\"Reload Flash\" reloads only the Flash part, this is usually faster but could result in catbomb.": "“重新载入Flash”只重新载入Flash部分，一般更快，但可能会导致网络异常错误。",
 

--- a/i18n/others/zh-CN.json
+++ b/i18n/others/zh-CN.json
@@ -60,7 +60,7 @@
   "RefreshGameDialogTip": {
       "text1": "提示：右键单击此按钮可重新载入Flash，按住Shift同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都",
       "b1": "不会弹出该确认对话框",
-      "text2": "请自担使用风险。"
+      "text2": "，请自担使用风险。"
   },
   "\"Refresh page\" is the same as pressing F5.": "“刷新游戏页面”与在页面上按F5效果相同。",
   "\"Reload Flash\" reloads only the Flash part, this is usually faster but could result in catbomb.": "“重新载入Flash”只重新载入Flash部分，一般更快，但可能会导致网络异常错误。",

--- a/i18n/others/zh-CN.json
+++ b/i18n/others/zh-CN.json
@@ -52,6 +52,15 @@
 
   "Resupply cost %d bauxite": "补给消耗了%d铝土",
 
+  "Refresh game": "刷新游戏确认",
+  "Confirm Refreshing": "刷新游戏",
+  "Are you sure to refresh the game?": "确定要刷新游戏吗？",
+  "Refresh page": "刷新游戏页面",
+  "Reload Flash": "重新载入Flash",
+  "Tip: Right clicking on this button reloads Flash and Left clicking with Alt key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.": "提示：右键单击此按钮可重新载入Flash，按住Alt同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都<b>不会弹出该确认对话框</b>，请自担使用风险。",
+  "\"Refresh page\" is the same as pressing F5.": "“刷新游戏页面”与在页面上按F5效果相同。",
+  "\"Reload Flash\" reloads only the Flash part, this is usually faster but could result in catbomb.": "“重新载入Flash”只重新载入Flash部分，一般更快，但可能会导致网络异常错误。",
+
   "Good day and welcome to poi %s! Before your use, here are some information for you": "诶嘿！欢迎使用 poi %s！使用之前看看下面！",
   "poi will never modify your game data package, but please use trusted executables and plugins!": "poi 不会修改任何游戏内的发包与收包，但是请使用可信的 poi 版本和可信的插件！",
   "poi does not use proxy by default, which you may change in settings panel.": "poi 默认不使用代理。更改代理的设置在设置面板中可以找到。",

--- a/i18n/others/zh-TW.json
+++ b/i18n/others/zh-TW.json
@@ -50,6 +50,8 @@
   "Armor": "裝甲",
   "Luck": "運",
 
+  "RefreshGameDialogTip": false,
+
   "Resupply cost %d bauxite": "補給消耗了%d鋁土",
 
   "Good day and welcome to poi %s! Before your use, here are some information for you": "誒嘿！歡迎使用 poi %s！使用之前看看下面！",

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -116,7 +116,7 @@ const PoiControl = connect((state, props) => ({
     $('kan-game webview').executeJavaScript('window.unalign()')
   }
   handleRefreshGameDialog = (e) => {
-      if (e.altKey) {
+      if (e.shiftKey) {
           gameRefreshPage();
           return;
       }
@@ -129,7 +129,7 @@ const PoiControl = connect((state, props) => ({
               <li>{__('"Refresh page" is the same as pressing F5.')}</li>
               <li>{__('"Reload Flash" reloads only the Flash part, this is usually faster but could result in catbomb.')}</li>
               </ul>
-              {__('Tip: Right clicking on this button reloads Flash and Left clicking with Alt key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.')}
+              {__('Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.')}
           </div>,
           [{ name: __("Refresh page"),
              func: gameRefreshPage,

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -25,9 +25,11 @@ config.on('config.set', (path, value) => {
 
 const PoiControl = connect((state, props) => ({
   muted: get(state, 'config.poi.content.muted', false),
+  refreshBtn: get(state, 'config.poi.showControlBarRefresh', false)
 }))(class poiControl extends React.Component {
   static propTypes = {
     muted: React.PropTypes.bool,
+    refreshBtn: React.PropTypes.bool
   }
   state = {
     extend: false,
@@ -114,6 +116,27 @@ const PoiControl = connect((state, props) => ({
   handleUnlockWebview = () => {
     $('kan-game webview').executeJavaScript('window.unalign()')
   }
+  handleRefreshGame = (e) => {
+    const webview = $('kan-game webview');
+    if (e.altKey) {
+      webview.reload();
+    } else {
+      webview.executeJavaScript(`
+        var doc;
+          if (document.getElementById('game_frame')) {
+            doc = document.getElementById('game_frame').contentDocument;
+          } else {
+            doc = document;
+          }
+          var flash = doc.getElementById('flashWrap');
+          if(flash) {
+            var flashInnerHTML = flash.innerHTML;
+            flash.innerHTML = '';
+            flash.innerHTML = flashInnerHTML;
+          }
+       `)
+    }
+  }
   handleSetExtend = () => {
     this.setState({extend: !this.state.extend})
   }
@@ -150,6 +173,15 @@ const PoiControl = connect((state, props) => ({
             <OverlayTrigger placement='right' overlay={<Tooltip id='poi-adjust-button' className='poi-control-tooltip'>{__('Auto adjust')}</Tooltip>}>
               <Button onClick={this.handleJustifyLayout} onContextMenu={this.handleUnlockWebview} bsSize='small'><FontAwesome name='arrows-alt' /></Button>
             </OverlayTrigger>
+            { !(this.props.refreshBtn)
+              ? null :
+              <OverlayTrigger placement='right' overlay={
+                  <Tooltip id='poi-refresh-button' className='poi-control-tooltip'>
+                    {"Reload Flash (Double Click), Refresh page (Alt+Double Click)"}
+                  </Tooltip>}>
+                <Button onDoubleClick={this.handleRefreshGame} bsSize='small'><FontAwesome name='refresh' /></Button>
+              </OverlayTrigger>
+            }
           </div>
         </Collapse>
         <Button onClick={this.handleSetExtend} bsSize='small' className={this.state.extend ? 'active' : ''}><FontAwesome name={this.state.extend ? 'angle-left' : 'angle-right'} /></Button>

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -25,10 +25,10 @@ config.on('config.set', (path, value) => {
 })
 
 const PoiControl = connect((state, props) => ({
-  muted: get(state, 'config.poi.content.muted', false)
+  muted: get(state, 'config.poi.content.muted', false),
 }))(class poiControl extends React.Component {
   static propTypes = {
-    muted: React.PropTypes.bool
+    muted: React.PropTypes.bool,
   }
   state = {
     extend: false,
@@ -117,8 +117,8 @@ const PoiControl = connect((state, props) => ({
   }
   handleRefreshGameDialog = (e) => {
     if (e.shiftKey) {
-      gameRefreshPage();
-      return;
+      gameRefreshPage()
+      return
     }
 
     let tipTexts = __("RefreshGameDialogTip");
@@ -136,12 +136,14 @@ const PoiControl = connect((state, props) => ({
         </ul>
         {tipTexts.text1}<b>{tipTexts.b1}</b>{tipTexts.text2}
       </div>,
-      [{ name: __("Refresh page"),
-         func: gameRefreshPage,
-         style: "warning" },
-       { name: __("Reload Flash"),
-         func: gameReloadFlash,
-         style: "danger" }]);
+      [ 
+        { name: __("Refresh page"),
+          func: gameRefreshPage,
+          style: "warning" },
+        { name: __("Reload Flash"),
+          func: gameReloadFlash,
+          style: "danger" },
+      ])
   }
   handleSetExtend = () => {
     this.setState({extend: !this.state.extend})

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -116,27 +116,32 @@ const PoiControl = connect((state, props) => ({
     $('kan-game webview').executeJavaScript('window.unalign()')
   }
   handleRefreshGameDialog = (e) => {
-      if (e.shiftKey) {
-          gameRefreshPage();
-          return;
-      }
+    if (e.shiftKey) {
+      gameRefreshPage();
+      return;
+    }
 
-      toggleModal(
-        __("Confirm Refreshing"),
-          <div>
-              {__("Are you sure to refresh the game?")}
-              <ul>
-              <li>{__('"Refresh page" is the same as pressing F5.')}</li>
-              <li>{__('"Reload Flash" reloads only the Flash part, this is usually faster but could result in catbomb.')}</li>
-              </ul>
-              {__('Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.')}
-          </div>,
-          [{ name: __("Refresh page"),
-             func: gameRefreshPage,
-             style: "warning" },
-           { name: __("Reload Flash"),
-             func: gameReloadFlash,
-             style: "danger" }]);
+    let tipTexts = __("RefreshGameDialogTip");
+    if (typeof tipTexts === "string") {
+      tipTexts = i18n.others.locales[i18n.others.defaultLocale]["RefreshGameDialogTip"];
+    }
+
+    toggleModal(
+      __("Confirm Refreshing"),
+        <div>
+        {__("Are you sure to refresh the game?")}
+        <ul>
+        <li>{__('"Refresh page" is the same as pressing F5.')}</li>
+        <li>{__('"Reload Flash" reloads only the Flash part, this is usually faster but could result in catbomb.')}</li>
+        </ul>
+        {tipTexts.text1}<b>{tipTexts.b1}</b>{tipTexts.text2}
+      </div>,
+      [{ name: __("Refresh page"),
+         func: gameRefreshPage,
+         style: "warning" },
+       { name: __("Reload Flash"),
+         func: gameReloadFlash,
+         style: "danger" }]);
   }
   handleSetExtend = () => {
     this.setState({extend: !this.state.extend})

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -121,10 +121,9 @@ const PoiControl = connect((state, props) => ({
       return
     }
 
-    let tipTexts = __("RefreshGameDialogTip");
-    if (typeof tipTexts === "string") {
-      tipTexts = i18n.others.locales[i18n.others.defaultLocale]["RefreshGameDialogTip"];
-    }
+    const tipTexts =
+      i18n.others.__("RefreshGameDialogTip") ||
+      i18n.others.locales["en-US"]["RefreshGameDialogTip"]
 
     toggleModal(
       __("Confirm Refreshing"),

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -122,21 +122,19 @@ const PoiControl = connect((state, props) => ({
       }
 
       toggleModal(
-        "Confirm Refreshing",
+        __("Confirm Refreshing"),
           <div>
-              Are you sure to refresh the game?
+              {__("Are you sure to refresh the game?")}
               <ul>
-              <li>"Refresh page" is the same as pressing F5.</li>
-              <li>"Reload Flash" reloads only the Flash part,
-              this is usually faster but could result in catbomb.</li>
+              <li>{__('"Refresh page" is the same as pressing F5.')}</li>
+              <li>{__('"Reload Flash" reloads only the Flash part, this is usually faster but could result in catbomb.')}</li>
               </ul>
-              Tip: Right clicking on this button reloads Flash and Left clicking with Alt key pressed refreshes the page,
-              both are <b>without confirmation</b>, use at your own risk.
+              {__('Tip: Right clicking on this button reloads Flash and Left clicking with Alt key pressed refreshes the page, both are <b>without confirmation</b>, use at your own risk.')}
           </div>,
-          [{ name: "Refresh page",
+          [{ name: __("Refresh page"),
              func: gameRefreshPage,
              style: "warning" },
-           { name: "Reload Flash",
+           { name: __("Reload Flash"),
              func: gameReloadFlash,
              style: "danger" }]);
   }
@@ -178,7 +176,7 @@ const PoiControl = connect((state, props) => ({
             </OverlayTrigger>
             <OverlayTrigger placement='right' overlay={
                 <Tooltip id='poi-refresh-button' className='poi-control-tooltip'>
-                  {"Refresh game"}
+                  {__("Refresh game")}
                 </Tooltip>}>
               <Button
                 onClick={this.handleRefreshGameDialog}

--- a/views/components/settings/parts/navigator-bar.es
+++ b/views/components/settings/parts/navigator-bar.es
@@ -2,6 +2,8 @@ import React from 'react'
 import FontAwesome from 'react-fontawesome'
 import { Button, ButtonGroup, FormControl, InputGroup, FormGroup, OverlayTrigger, Tooltip } from 'react-bootstrap'
 
+import { gameRefreshPage, gameReloadFlash } from 'views/services/utils'
+
 const {config, i18n, $} = window
 const __ = i18n.setting.__.bind(i18n.setting)
 const webview = $('kan-game webview')
@@ -80,25 +82,6 @@ class NavigatorBar extends React.Component {
   onClickStop = (e) => {
     webview.stop()
   }
-  onClickRefresh = (e) => {
-    webview.reload()
-  }
-  onRightClickRefresh = (e) => {
-    webview.executeJavaScript(`
-      var doc;
-      if (document.getElementById('game_frame')) {
-        doc = document.getElementById('game_frame').contentDocument;
-      } else {
-        doc = document;
-      }
-      var flash = doc.getElementById('flashWrap');
-      if(flash) {
-        var flashInnerHTML = flash.innerHTML;
-        flash.innerHTML = '';
-        flash.innerHTML = flashInnerHTML;
-      }
-    `)
-  }
   onClickHomepage = (e) => {
     config.set('poi.homepage', this.state.url)
   }
@@ -146,7 +129,7 @@ class NavigatorBar extends React.Component {
         <div className='navigator-btn'>
           <ButtonGroup>
             <Button bsSize='small' bsStyle='primary' onClick={navigateAction}>{navigateIcon}</Button>
-            <Button bsSize='small' bsStyle='warning' onClick={this.onClickRefresh} onContextMenu={this.onRightClickRefresh}><FontAwesome name='refresh' /></Button>
+            <Button bsSize='small' bsStyle='warning' onClick={gameRefreshPage} onContextMenu={gameReloadFlash}><FontAwesome name='refresh' /></Button>
           </ButtonGroup>
           <ButtonGroup style={{marginLeft: 5}}>
             <OverlayTrigger placement='top' overlay={<Tooltip id='nav-homepage'>{__ ('Set as homepage')}</Tooltip>}>

--- a/views/components/settings/parts/poi-config.es
+++ b/views/components/settings/parts/poi-config.es
@@ -804,10 +804,6 @@ class PoiConfig extends Component {
               label={__('Enter safe mode on next startup')}
               configName="poi.enterSafeMode"
               defaultVal={false} />
-            <CheckboxLabelConfig
-              label={__('Show Refresh button on control bar')}
-              configName="poi.showControlBarRefresh"
-              defaultVal={false} />
           </Grid>
         </div>
       </div>

--- a/views/components/settings/parts/poi-config.es
+++ b/views/components/settings/parts/poi-config.es
@@ -804,6 +804,10 @@ class PoiConfig extends Component {
               label={__('Enter safe mode on next startup')}
               configName="poi.enterSafeMode"
               defaultVal={false} />
+            <CheckboxLabelConfig
+              label={__('Show Refresh button on control bar')}
+              configName="poi.showControlBarRefresh"
+              defaultVal={false} />
           </Grid>
         </div>
       </div>

--- a/views/services/utils.es
+++ b/views/services/utils.es
@@ -37,3 +37,24 @@ export const damagedCheck = ({$ships, $equips}, {sortieStatus, escapedPos}, {fle
   }
   return damagedShips
 }
+
+export const gameRefreshPage = () => {
+  $('kan-game webview').reload();
+}
+
+export const gameReloadFlash = () => {
+  $('kan-game webview').executeJavaScript(`
+  var doc;
+  if (document.getElementById('game_frame')) {
+    doc = document.getElementById('game_frame').contentDocument;
+  } else {
+    doc = document;
+  }
+  var flash = doc.getElementById('flashWrap');
+  if(flash) {
+    var flashInnerHTML = flash.innerHTML;
+    flash.innerHTML = '';
+    flash.innerHTML = flashInnerHTML;
+  }
+  `)
+}


### PR DESCRIPTION
Adding a refresh button on control bar:

![2017-03-20_173519_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/24122801/a3327e90-0d93-11e7-85a7-216582a8a2b4.jpg)


## Changes

- interactions:

    - Click: Opens a dialog that user can choose between "Refresh page" or "Reload Flash"
    - Shift+Click: Refresh page
    - Right Click: Reload Flash

- togglable through common setting page

    - boolean setting located at `config.poi.showControlBarRefresh`,
      `false` by default.

## Notes

- ~~it's possible to merge this feature completely into https://github.com/poooi/plugin-prophet which might require main app to provide a way of inserting buttons into the control bar~~ (cancelled due to probably unnecessary complication)
- ~~a planned future improvement is to allow fine-grained control of whether to enable this function depending on branch prediction (e.g. allow user to specify things like "when triggered, allow refresh on 2-2A, but do nothing on any node of 5-4"), which would become easier to impl once the bullet above is supported~~ (same as above)
- ~~is it possible to attach [flash reloading function](https://github.com/poooi/poi/blob/6e6d1242b7a3062306c55c6c045e300ebd3693d9/views/components/settings/parts/navigator-bar.es#L86-L101) to `webview`? just to reduce some duplicated code.~~ (refactored to ` views/services/utils`)


