### PR TITLE
Add tab-auto-switch function

### DIFF
--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -139,6 +139,7 @@
   "Data version": "データバージョン",
   "Update data": "データを更新する",
   "Display Final Stage Notification": "最終戦ヒントを表示する",
+  "Switch to Plugin Automatically": "場によってプラグインを自動に表示する",
   "Safe Mode": "セーフモード",
   "Poi is running in safe mode, plugins are not enabled automatically.": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。",
   "Enter safe mode on next startup": "次回起動時にセーフモードにする",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -139,6 +139,7 @@
   "Data version": "数据版本",
   "Update data": "更新数据",
   "Display Final Stage Notification": "显示最终战提示",
+  "Switch to Plugin Automatically": "自动切换至插件",
   "Safe Mode": "安全模式",
   "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 运行在安全模式下，插件没有自动启用。",
   "Enter safe mode on next startup": "下次启动进入安全模式",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -139,6 +139,7 @@
   "Data version": "資料版本",
   "Update data": "更新資料",
   "Display Final Stage Notification": "顯示最終戰提示",
+  "Switch to Plugin Automatically": "自動切換至擴展",
   "Safe Mode": "安全模式",
   "Poi is running in safe mode, plugins are not enabled automatically.": "Poi 運行在安全模式下，擴展程式沒有自動啓用。",
   "Enter safe mode on next startup": "下次啓動進入安全模式",

--- a/views/components/settings/parts/poi-config.es
+++ b/views/components/settings/parts/poi-config.es
@@ -761,6 +761,10 @@ class PoiConfig extends Component {
               label={__('Display Final Stage Notification')}
               configName="poi.lastbattle.enabled"
               defaultVal={true} />
+            <CheckboxLabelConfig
+              label={__('Switch to Plugin Automatically')}
+              configName="poi.autoswitch.enabled"
+              defaultVal={true} />
           </Grid>
         </div>
         <div className="form-group">

--- a/views/tabarea.es
+++ b/views/tabarea.es
@@ -216,6 +216,29 @@ export default connect(
       }
     })
   }
+  handleResponse = (e) => {
+    let toSwitch
+    if (['/kcsapi/api_port/port',
+      '/kcsapi/api_get_member/ndock',
+      '/kcsapi/api_get_member/kdock',
+    ].includes(e.detail.path)) {
+      toSwitch = 'mainView'
+    }
+    if (['/kcsapi/api_get_member/preset_deck',
+      '/kcsapi/api_req_hensei/change',
+      '/kcsapi/api_req_kaisou/slot_exchange_index',
+      '/kcsapi/api_req_kaisou/slotset',
+    ].includes(e.detail.path)) {
+      toSwitch = 'shipView'
+    }
+    for (const [id, switchPluginPath] of this.props.plugins.map(plugin => [plugin.id, plugin.switchPluginPath || []])) {
+      if (switchPluginPath.includes(e.detail.path)) {
+        toSwitch = id
+        break
+      }
+    }
+    this.selectTab(toSwitch)
+  }
   componentWillReceiveProps(nextProps) {
     if (nextProps.doubleTabbed != this.props.doubleTabbed)
       this.dispatchTabChangeEvent({
@@ -225,10 +248,12 @@ export default connect(
   componentDidMount() {
     this.handleKeyDown()
     window.addEventListener('game.start', this.handleKeyDown)
+    window.addEventListener('game.response', this.handleResponse)
     window.openSettings = this.handleCmdCommaKeyDown
   }
   componentWillUnmount() {
     window.removeEventListener('game.start', this.handleKeyDown)
+    window.removeEventListener('game.response', this.handleResponse)
   }
   // All displaying plugins
   listedPlugins = () => {

--- a/views/tabarea.es
+++ b/views/tabarea.es
@@ -15,7 +15,7 @@ import PluginWrap from './plugin-wrapper'
 
 import { isInGame } from 'views/utils/game-utils'
 
-const {i18n, dbg, dispatch} = window
+const {i18n, dbg, dispatch, config} = window
 const __ = i18n.others.__.bind(i18n.others)
 
 

--- a/views/tabarea.es
+++ b/views/tabarea.es
@@ -217,27 +217,30 @@ export default connect(
     })
   }
   handleResponse = (e) => {
-    let toSwitch
-    if (['/kcsapi/api_port/port',
-      '/kcsapi/api_get_member/ndock',
-      '/kcsapi/api_get_member/kdock',
-    ].includes(e.detail.path)) {
-      toSwitch = 'mainView'
-    }
-    if (['/kcsapi/api_get_member/preset_deck',
-      '/kcsapi/api_req_hensei/change',
-      '/kcsapi/api_req_kaisou/slot_exchange_index',
-      '/kcsapi/api_req_kaisou/slotset',
-    ].includes(e.detail.path)) {
-      toSwitch = 'shipView'
-    }
-    for (const [id, switchPluginPath] of this.props.plugins.map(plugin => [plugin.id, plugin.switchPluginPath || []])) {
-      if (switchPluginPath.includes(e.detail.path)) {
-        toSwitch = id
-        break
+    if (config.get('poi.autoswitch.enabled', true)) {
+      let toSwitch
+      if (['/kcsapi/api_port/port',
+        '/kcsapi/api_get_member/ndock',
+        '/kcsapi/api_get_member/kdock',
+        '/kcsapi/api_get_member/questlist',
+      ].includes(e.detail.path)) {
+        toSwitch = 'mainView'
       }
+      if (['/kcsapi/api_get_member/preset_deck',
+        '/kcsapi/api_req_hensei/change',
+        '/kcsapi/api_req_kaisou/slot_exchange_index',
+        '/kcsapi/api_req_kaisou/slotset',
+      ].includes(e.detail.path)) {
+        toSwitch = 'shipView'
+      }
+      for (const [id, switchPluginPath] of this.props.plugins.map(plugin => [plugin.id, plugin.switchPluginPath || []])) {
+        if (switchPluginPath.includes(e.detail.path)) {
+          toSwitch = id
+          break
+        }
+      }
+      this.selectTab(toSwitch)
     }
-    this.selectTab(toSwitch)
   }
   componentWillReceiveProps(nextProps) {
     if (nextProps.doubleTabbed != this.props.doubleTabbed)


### PR DESCRIPTION
Plugin add a new option: `switchPluginPath`
`switchPluginPath` is a array includes api path when should switch to the plugin.
example:
```js
export const switchPluginPath = [
  '/kcsapi/api_req_map/start',
  '/kcsapi/api_req_practice/battle',
  '/kcsapi/api_req_map/next',
]
```
if conflicted, the plugin with higher priority will be chosen.