### PR TITLE
Support valid function

### DIFF
--- a/views/tabarea.es
+++ b/views/tabarea.es
@@ -234,9 +234,10 @@ export default connect(
         toSwitch = 'shipView'
       }
       for (const [id, switchPluginPath] of this.props.plugins.map(plugin => [plugin.id, plugin.switchPluginPath || []])) {
-        if (switchPluginPath.includes(e.detail.path)) {
-          toSwitch = id
-          break
+        for (const switchPath of switchPluginPath) {
+          if (switchPath === e.detail.path || (switchPath.path === e.detail.path && switchPath.valid && switchPath.valid())) {
+            toSwitch = id
+          }
         }
       }
       this.selectTab(toSwitch)


### PR DESCRIPTION
Now two types of `switchPluginPath` is supported
```js
export const switchPluginPath = [
  'path1', // switch to plugin when get this api
  {
    path: 'path2',
    valid: function() { ... },
  }, // switch to plugin when get this api and valid() return true
]
```