### PR TITLE
Alternative hidpi support

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,8 +92,6 @@ global.mainWindow = mainWindow = null
 // https://github.com/electron/electron/issues/7655#issuecomment-259688853
 if (process.platform === 'win32') {
   app.commandLine.appendSwitch('enable-use-zoom-for-dsf', 'false')
-  app.commandLine.appendSwitch('high-dpi-support', 'true')
-  app.commandLine.appendSwitch('force-device-scale-factor', '1')
 }
 
 app.on ('window-all-closed', () => {

--- a/assets/js/plugin-preload.js
+++ b/assets/js/plugin-preload.js
@@ -1,4 +1,4 @@
-const { remote, screen } = require('electron')
+const { remote } = require('electron')
 const ROOT = remote.getGlobal('ROOT')
 const MODULE_PATH = remote.getGlobal('MODULE_PATH')
 const config = remote.require('./lib/config')
@@ -23,4 +23,4 @@ window.addEventListener('unload', (e) => {
   config.removeListener('config.set', handleZoom)
 })
 
-document.addEventListener('DOMContentLoaded', () => onZoomChange(config.get('poi.zoomLevel', screen.getPrimaryDisplay().scaleFactor)))
+document.addEventListener('DOMContentLoaded', () => onZoomChange(config.get('poi.zoomLevel', 1)))

--- a/views/components/settings/parts/display-config.es
+++ b/views/components/settings/parts/display-config.es
@@ -1,6 +1,6 @@
 import path from 'path-extra'
 import fs from 'fs-extra'
-import { shell, screen } from 'electron'
+import { shell } from 'electron'
 import { Grid, Col, Button, ButtonGroup, FormControl, Checkbox, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import React from 'react'
@@ -169,18 +169,16 @@ const ChangeThemeConfig = connect((state, props) => ({
   }
 })
 
-const defaultZoomLevel = screen.getPrimaryDisplay().scaleFactor
-
 const ZoomingConfig = connect(() => (
   (state, props) => ({
-    zoomLevel: get(state.config, 'poi.zoomLevel', defaultZoomLevel),
+    zoomLevel: get(state.config, 'poi.zoomLevel', 1),
   })
 ))(class zoomingConfig extends Component {
   static propTypes = {
     zoomLevel: React.PropTypes.number,
   }
   state = {
-    zoomLevel: config.get('poi.zoomLevel', defaultZoomLevel),
+    zoomLevel: config.get('poi.zoomLevel', 1),
   }
   handleChangeZoomLevel = (e) => {
     config.set('poi.zoomLevel', this.state.zoomLevel)

--- a/views/components/settings/parts/display-config.es
+++ b/views/components/settings/parts/display-config.es
@@ -319,10 +319,12 @@ const ChangeResolutionConfig = connect((state, props) => ({
     if (this.props.webview.useFixedResolution) {
       config.set('poi.webview.width', -1)
     } else {
-      config.set('poi.webview.width', this.props.webview.width)
+      const { devicePixelRatio } = window
+      config.set('poi.webview.width', Math.round(this.props.webview.width * devicePixelRatio))
     }
   }
   render() {
+    const { devicePixelRatio } = window
     return (
       <Grid>
         <Col xs={8}>
@@ -338,7 +340,9 @@ const ChangeResolutionConfig = connect((state, props) => ({
            value={this.props.webview.width}
            onChange={this.handleSetWebviewWidth}
            disabled={!this.props.webview.useFixedResolution} >
-            <option key={-1} value={this.props.webview.width} hidden>{Math.round(this.props.webview.width/800*100)}%</option>
+            <option key={-1} value={Math.round(this.props.webview.width * devicePixelRatio)} hidden>
+              {Math.round(this.props.webview.width / 800 * 100)}%
+            </option>
             {
               [0, 1, 2, 3].map((i) => {
                 return (
@@ -353,7 +357,7 @@ const ChangeResolutionConfig = connect((state, props) => ({
         <Col id="poi-resolution-config" xs={12} style={{display: 'flex', alignItems: 'center'}}>
           <div style={{flex: 1}}>
             <FormControl type="number"
-             value={Math.round(this.props.webview.width)}
+             value={Math.round(this.props.webview.width * devicePixelRatio)}
              onChange={this.handleSetWebviewWidth}
              readOnly={!this.props.webview.useFixedResolution} />
           </div>

--- a/views/components/settings/parts/display-config.es
+++ b/views/components/settings/parts/display-config.es
@@ -365,7 +365,7 @@ const ChangeResolutionConfig = connect((state, props) => ({
             x
           </div>
           <div style={{flex: 1}}>
-            <FormControl type="number" value={Math.round(this.props.webview.height)} readOnly />
+            <FormControl type="number" value={Math.round(this.props.webview.height * devicePixelRatio)} readOnly />
           </div>
           <div style={{flex: 'none', width: 15, paddingLeft: 5}}>
             px

--- a/views/components/settings/parts/display-config.es
+++ b/views/components/settings/parts/display-config.es
@@ -337,7 +337,7 @@ const ChangeResolutionConfig = connect((state, props) => ({
         </Col>
         <Col xs={4}>
           <FormControl componentClass="select"
-           value={this.props.webview.width}
+           value={Math.round(this.props.webview.width * devicePixelRatio)}
            onChange={this.handleSetWebviewWidth}
            disabled={!this.props.webview.useFixedResolution} >
             <option key={-1} value={Math.round(this.props.webview.width * devicePixelRatio)} hidden>

--- a/views/env-parts/getter.es
+++ b/views/env-parts/getter.es
@@ -2,7 +2,7 @@ import { observer, observe } from 'redux-observers'
 import { createSelector } from 'reselect'
 import { map, get, mapValues } from 'lodash'
 import path from 'path-extra'
-import { remote, screen } from 'electron'
+import { remote } from 'electron'
 
 import { store } from 'views/create-store'
 import { buildArray } from 'views/utils/tools'
@@ -36,7 +36,7 @@ Object.defineProperty(window, 'webviewWidth', {get: () => {
   return config.get('poi.webview.width', -1)
 }})
 Object.defineProperty(window, 'zoomLevel', {get: () => {
-  return config.get('poi.zoomLevel', screen.getPrimaryDisplay().scaleFactor)
+  return config.get('poi.zoomLevel', 1)
 }})
 Object.defineProperty(window, 'useSVGIcon', {get: () => {
   return config.get('poi.useSVGIcon', false)

--- a/views/redux/layout/index.es
+++ b/views/redux/layout/index.es
@@ -1,4 +1,4 @@
-const {config} = window
+const { config, devicePixelRatio } = window
 
 const initState = {
   window: {
@@ -6,8 +6,8 @@ const initState = {
     height: window.innerHeight,
   },
   webview: {
-    width: config.get('poi.webview.width', 800),
-    height: config.get('poi.webview.width', 800) * 0.6,
+    width: config.get('poi.webview.width', 800 * Math.round(devicePixelRatio)),
+    height: config.get('poi.webview.width', 800 * Math.round(devicePixelRatio)) * 0.6,
     useFixedResolution: true,
   },
 }

--- a/views/services/device-pixel-ratio-detector.es
+++ b/views/services/device-pixel-ratio-detector.es
@@ -1,0 +1,22 @@
+import EventEmitter from 'events'
+
+export class devicePixelRatioDetector extends EventEmitter {
+  constructor() {
+    super()
+    const { devicePixelRatio } = window
+    this.matchMediaMin = window.matchMedia(`screen and (min-resolution: ${devicePixelRatio}dppx)`)
+    this.matchMediaMax = window.matchMedia(`screen and (max-resolution: ${devicePixelRatio}dppx)`)
+    this.matchMediaMin.addListener(this.callback)
+    this.matchMediaMax.addListener(this.callback)
+  }
+  callback = e => {
+    this.matchMediaMin.removeListener(this.callback)
+    this.matchMediaMax.removeListener(this.callback)
+    const { devicePixelRatio } = window
+    this.matchMediaMin = window.matchMedia(`screen and (min-resolution: ${devicePixelRatio}dppx)`)
+    this.matchMediaMax = window.matchMedia(`screen and (max-resolution: ${devicePixelRatio}dppx)`)
+    this.matchMediaMin.addListener(this.callback)
+    this.matchMediaMax.addListener(this.callback)
+    this.emit('change', devicePixelRatio)
+  }
+}

--- a/views/services/layout.es
+++ b/views/services/layout.es
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash'
-import { remote, screen } from 'electron'
+import { remote } from 'electron'
 
 const {config, $} = window
 
@@ -143,7 +143,7 @@ const setCSSDebounced = debounce(setCSS, 200)
 const adjustSize = () => {
   const layout = config.get('poi.layout', 'horizontal')
   const reversed = config.get('poi.reverseLayout', false)
-  const zoomLevel = config.get('poi.zoomLevel', screen.getPrimaryDisplay().scaleFactor)
+  const zoomLevel = config.get('poi.zoomLevel', 1)
   const doubleTabbed = config.get('poi.tabarea.double', false)
   const panelMinSize = config.get('poi.panelMinSize', 1)
   let webviewWidth = config.get('poi.webview.width', -1)

--- a/views/services/layout.es
+++ b/views/services/layout.es
@@ -159,6 +159,11 @@ const adjustSize = () => {
       webviewWidth = window.innerWidth
       webviewHeight = Math.round(webviewWidth / 800.0 * 480.0)
     }
+  } else {
+    // HiDPI fix
+    const { devicePixelRatio } = window
+    webviewWidth = Math.round(webviewWidth / devicePixelRatio)
+    webviewHeight = Math.round(webviewHeight / devicePixelRatio)
   }
 
   // Set a smaller webview size if it takes too much place

--- a/views/services/layout.es
+++ b/views/services/layout.es
@@ -1,5 +1,6 @@
 import { debounce } from 'lodash'
 import { remote } from 'electron'
+import { devicePixelRatioDetector } from './device-pixel-ratio-detector'
 
 const {config, $} = window
 
@@ -275,3 +276,6 @@ config.on('config.set', (path, value) => {
     break
   }
 })
+
+const detector = new devicePixelRatioDetector()
+detector.on('change', adjustSize)


### PR DESCRIPTION
Use a alternative HiDPI logic:

- Set DPI scale from system setting
- Webview’s size now is affected by `window.devicePixelRatio` to ensure getting actual size for screen

This PR closes #1412 , closes #1408 and closes #1403