### PR TITLE
change to a non-blocking behavior of opening directories

### DIFF
--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -10,8 +10,15 @@ import FontAwesome from 'react-fontawesome'
 import { gameRefreshPage, gameReloadFlash } from 'views/services/utils'
 
 const {$, i18n, config, APPDATA_PATH, toggleModal} = window
-const {openItem} = shell
+const {openExternal} = shell
 const __ = i18n.others.__.bind(i18n.others)
+
+const openItemAsync = (dir, source=null) => {
+  openExternal(`file://${dir}`, {}, err => {
+    if (err)
+      console.error('${dir}: Failed to open item asynchronously', err)
+  })
+}
 
 // Controller icon bar
 const {openFocusedWindowDevTools} = remote.require('./lib/window')
@@ -73,7 +80,7 @@ const PoiControl = connect((state, props) => ({
       fs.ensureDirSync(path.join(dir, 'Kanpani'))
       fs.ensureDirSync(path.join(dir, 'FlowerKnightGirls'))
       fs.ensureDirSync(path.join(dir, 'ToukenRanbu'))
-      openItem(dir)
+      openItemAsync(dir, 'handleOpenCacheFolder')
     }
     catch (e) {
       window.toggleModal(__('Open cache dir'), __("Failed. Perhaps you don't have permission to it."))
@@ -84,7 +91,7 @@ const PoiControl = connect((state, props) => ({
     dir = path.join(dir, 'kancolle', 'kcs', 'resources', 'swf', 'ships')
     try {
       fs.ensureDirSync(dir)
-      openItem(dir)
+      openItemAsync(dir, 'handleOpenMakaiFolder')
     } catch (e) {
       window.toggleModal(__('Open makai dir'), __("Failed. Perhaps you don't have permission to it."))
     }
@@ -94,7 +101,7 @@ const PoiControl = connect((state, props) => ({
       const d = process.platform == 'darwin' ? path.join(remote.app.getPath('home'), 'Pictures', 'Poi') : path.join(APPDATA_PATH, 'screenshots')
       const screenshotPath = config.get('poi.screenshotPath', d)
       fs.ensureDirSync(screenshotPath)
-      openItem(screenshotPath)
+      openItemAsync(screenshotPath,'handleOpenScreenshotFolder')
     }
     catch (e) {
       window.toggleModal(__('Open screenshot dir'), __("Failed. Perhaps you don't have permission to it."))

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -15,8 +15,10 @@ const __ = i18n.others.__.bind(i18n.others)
 
 const openItemAsync = (dir, source=null) => {
   openExternal(`file://${dir}`, {}, err => {
-    if (err)
-      console.error('${dir}: Failed to open item asynchronously', err)
+    if (err) {
+      const prefix = (source && `${source}: `) || ''
+      console.error(`${prefix}Failed to open item "${dir}" asynchronously`, err)
+    }
   })
 }
 


### PR DESCRIPTION
change to a non-blocking behavior of opening directories for some quickbar buttons, which allows user to browse the directory while keeping main UI functioning (previously opening a directory blocks UI)