### PR TITLE
added http basic auth support #1496

### DIFF
--- a/app.js
+++ b/app.js
@@ -180,6 +180,15 @@ app.on('ready', () => {
     })
   }
 })
+// http basic auth
+app.on('login', (event, webContents, request, authInfo, callback) => {
+  event.preventDefault()
+  mainWindow.webContents.send('http-basic-auth', 'login')
+  ipcMain.once ('basic-auth-info', (event, usr, pwd) => {
+    callback(usr, pwd)
+  })
+})
+
 
 ipcMain.on ('refresh-shortcut', () => {
   shortcut.unregister()

--- a/i18n/others/en-US.json
+++ b/i18n/others/en-US.json
@@ -47,7 +47,9 @@
   "AntiAir": "AntiAir",
   "Armor": "Armor",
   "Luck": "Luck",
-
+  "Website requires login": "Website requires login",
+  "Username":"Username",
+  "Password":"Password",
   "RefreshGameDialogTip": {
       "text1": "Tip: Right clicking on this button reloads Flash and Left clicking with Shift key pressed refreshes the page, both are ",
       "b1": "without confirmation",

--- a/i18n/others/ja-JP.json
+++ b/i18n/others/ja-JP.json
@@ -59,6 +59,9 @@
   "Are you sure to refresh the game?": "リロードですか？",
   "Refresh page": "ページをリロード",
   "Reload Flash": "ゲームだけをリロード",
+  "Website requires login": "Website requires login",
+  "Username":"Username",
+  "Password":"Password",
   "RefreshGameDialogTip": {
     "text1": "ヒント：右クリックしてゲームだけをリロード、Shift キーを押して左クリックしてページをリロード。この二つの方法は",
     "b1": "確認ダイアログがありません",

--- a/i18n/others/ko-KR.json
+++ b/i18n/others/ko-KR.json
@@ -46,7 +46,9 @@
   "AntiAir": "대공",
   "Armor": "장갑",
   "Luck": "운",
-
+  "Website requires login": "Website requires login",
+  "Username":"Username",
+  "Password":"Password",
   "RefreshGameDialogTip": false,
 
   "doyouknow-prefix": "[TIP] ",

--- a/i18n/others/zh-CN.json
+++ b/i18n/others/zh-CN.json
@@ -60,6 +60,9 @@
   "Are you sure to refresh the game?": "确定要刷新游戏吗？",
   "Refresh page": "刷新游戏页面",
   "Reload Flash": "重新载入 Flash",
+  "Website requires login": "网站需要登陆",
+  "Username":"用户名",
+  "Password":"密码",
   "RefreshGameDialogTip": {
     "text1": "提示：右键单击此按钮可重新载入 Flash，按住 Shift 同时左键单击此按钮可刷新游戏页面，但这两种刷新方法都",
     "b1": "不会弹出该确认对话框",

--- a/i18n/others/zh-TW.json
+++ b/i18n/others/zh-TW.json
@@ -60,6 +60,9 @@
   "Are you sure to refresh the game?": "確定要重新整理遊戲嗎？",
   "Refresh page": "重新整理遊戲頁面",
   "Reload Flash": "重新載入 Flash",
+  "Website requires login": "網站需要登錄",
+  "Username":"帳號",
+  "Password":"密碼", 
   "RefreshGameDialogTip": {
     "text1": "提示：右鍵單擊此按鈕可重新載入 Flash，按住 Shift 同時左鍵單擊此按鈕可重新整理遊戲頁面，但這兩種重新整理方法都",
     "b1": "不會彈出該確認對話方塊",

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
     <poi-toast>
       <poi-toast-trigger />
     </poi-toast>
+    <poi-auth>
+      <poi-auth-trigger />
+    </poi-auth>
     <poi-app>
       <div id='poi-app-container'>
         <poi-nav>

--- a/views/app.es
+++ b/views/app.es
@@ -12,6 +12,7 @@ import PoiMapReminder from './components/info/map-reminder'
 import { PoiControl } from './components/info/control'
 import { Toastr } from './components/info/toastr'
 import { ModalTrigger } from './components/etc/modal'
+import { BasicAuth } from './utils/http-basic-auth'
 
 const {EXROOT, $} = window
 const config = remote.require('./lib/config')
@@ -72,3 +73,4 @@ ReactDOM.render(
 ReactDOM.render(<ModalTrigger />, $('poi-modal-trigger'))
 ReactDOM.render(<Toastr />, $('poi-toast-trigger'))
 ReactDOM.render(<CustomCssInjector />, $('poi-css-injector'))
+ReactDOM.render(<BasicAuth />, $('poi-auth-trigger'))

--- a/views/utils/http-basic-auth.es
+++ b/views/utils/http-basic-auth.es
@@ -1,0 +1,77 @@
+import { ipcRenderer } from 'electron'
+import React from 'react'
+import { Modal, Form, FormGroup, Col, ControlLabel, FormControl, Button } from 'react-bootstrap'
+const {i18n} = window
+const __ = i18n.others.__.bind(i18n.others)
+
+const BALogin = (usr,pwd) => {
+  ipcRenderer.send('basic-auth-info', usr, pwd)
+}
+class BasicAuth extends React.Component {
+  state ={
+    showModal: false,
+    user:'',
+    password:'',
+  }
+  login = (usr, passwd) => {
+    BALogin(this.state.user, this.state.password)
+    this.setState({ 
+      showModal: false,
+      user: '',
+      password: '',
+    })
+  }
+  close = () => {
+    this.setState({ showModal: false })
+  }
+  open = () => {
+    this.setState({ showModal: true })
+  }
+  handleUser = (e) => {
+    this.setState({ user: e.target.value })
+  }
+  handlePassword = (e) => {
+    this.setState({ password: e.target.value })
+  }
+  componentDidMount = () => {
+    ipcRenderer.on('http-basic-auth', (event, arg) => {
+      this.open()
+    })
+  }
+  render() {
+    return (
+      <Modal show={this.state.showModal} onHide={this.close}>
+        <Modal.Header closeButton>
+          <Modal.Title>{__("Website requires login")}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form horizontal>
+            <FormGroup controlId="formHorizontalEmail">
+              <Col componentClass={ControlLabel} sm={2}>
+                {__("Username")}
+              </Col>
+              <Col sm={10}>
+                <FormControl value={this.state.user} type="username" placeholder={__("Username")} onChange={this.handleUser} />
+              </Col>
+            </FormGroup>
+  
+            <FormGroup controlId="formHorizontalPassword">
+              <Col componentClass={ControlLabel} sm={2}>
+                {__("Password")}
+              </Col>
+              <Col sm={10}>
+                <FormControl value={this.state.password} type="password" placeholder={__("Password")} onChange={this.handlePassword}/>
+              </Col>
+            </FormGroup>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.close}>{__("Cancel")}</Button>
+          <Button bsStyle="primary" onClick={this.login}>{__("Confirm")}</Button>
+        </Modal.Footer>
+      </Modal>
+    )
+  }
+}
+
+export { BasicAuth }


### PR DESCRIPTION
Implemented #1496

When website wants to challenge an http basic auth, a login form will pop out to collect credentials.
<img width="1262" alt="screen shot 2017-07-19 at 5 31 38 pm" src="https://user-images.githubusercontent.com/12995396/28361037-fd6e310e-6ca9-11e7-8d8d-f5bfc86da6b0.png">
<img width="250" alt="screen shot 2017-07-19 at 5 32 16 pm" src="https://user-images.githubusercontent.com/12995396/28361232-bfe4ec78-6caa-11e7-876a-86d1c967aa23.png">


If the credential is incorrect, the form will pop out again if the server still accepts login attempt.

Due to the limitation of electron, the cancel behavior will not call back the server with any further information, and the connection will be closed by server if timed out. However a standard browser will try to connect without any auth information instead, which is better for using.

The i18n is not completed yet , some language is using english translation instead

