### PR TITLE
Make touchbar input stateless

### DIFF
--- a/lib/touchbar.es
+++ b/lib/touchbar.es
@@ -92,7 +92,7 @@ export const touchBar = new TouchBar({
   escapeItem: poibutton,
 })
 //Change Volume btn
-export const touchBarreinit = () => {
+export const touchBarReInit = () => {
   volume.icon = config.get('poi.content.muted') ? path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-off.png') : path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-up.png')
 }
 //Touchbar reset

--- a/lib/touchbar.es
+++ b/lib/touchbar.es
@@ -92,13 +92,8 @@ export const touchBar = new TouchBar({
   escapeItem: poibutton,
 })
 //Change Volume btn
-export const touchBarreinit = (muted) => {
-  if (muted) {
-    volume.icon = path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-off.png')
-  }
-  else {
-    volume.icon = path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-up.png')
-  }
+export const touchBarreinit = () => {
+  volume.icon = config.get('poi.content.muted') ? path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-off.png') : path.join(ROOT, 'assets', 'img', 'touchbar', 'volume-up.png')
 }
 //Touchbar reset
 export const touchBarReset = () => {mainWindow.setTouchBar(touchBar)}

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -37,7 +37,6 @@ config.on('config.set', (path, value) => {
 
 const PoiControl = connect((state, props) => ({
   muted: get(state, 'config.poi.content.muted', false),
-  //tbtriggered: get(state, 'config.poi.touchbar.triggered', null),
 }))(class poiControl extends React.Component {
   static propTypes = {
     muted: PropTypes.bool,
@@ -161,7 +160,7 @@ const PoiControl = connect((state, props) => ({
   }
   handleTouchbar = (props) => {
     //load Touchbar-related functions only when touchbar is triggered
-    const {touchBarreinit, refreshconfirm, touchBarReset} = remote.require('./lib/touchbar')
+    const {touchBarReInit, refreshconfirm, touchBarReset} = remote.require('./lib/touchbar')
     //workaround for the input event not defined
     switch (props) {
     case 'refresh':
@@ -200,7 +199,7 @@ const PoiControl = connect((state, props) => ({
       break
     case 'volume':
       this.handleSetMuted()
-      touchBarreinit()
+      touchBarReInit()
       break
     case 'screenshot':
       this.handleCapturePage()

--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -37,7 +37,7 @@ config.on('config.set', (path, value) => {
 
 const PoiControl = connect((state, props) => ({
   muted: get(state, 'config.poi.content.muted', false),
-  tbtriggered: get(state, 'config.poi.touchbar.triggered', null),
+  //tbtriggered: get(state, 'config.poi.touchbar.triggered', null),
 }))(class poiControl extends React.Component {
   static propTypes = {
     muted: PropTypes.bool,
@@ -198,13 +198,9 @@ const PoiControl = connect((state, props) => ({
     case 'cachedir':
       this.handleOpenCacheFolder()
       break
-    case 'mute':
-      config.set('poi.content.muted', true)
-      touchBarreinit(true)
-      break
-    case 'unmute':
-      config.set('poi.content.muted', false)
-      touchBarreinit(false)
+    case 'volume':
+      this.handleSetMuted()
+      touchBarreinit()
       break
     case 'screenshot':
       this.handleCapturePage()
@@ -217,7 +213,6 @@ const PoiControl = connect((state, props) => ({
       break
     default:
     }
-    config.set('poi.touchbar.triggered', null)
   }
   sendEvent = (isExtend) => {
     const event = new CustomEvent('alert.change', {
@@ -229,8 +224,15 @@ const PoiControl = connect((state, props) => ({
     })
     window.dispatchEvent(event)
   }
+  componentDidMount = () => {
+    //Stateless touchbar input receiver
+    if (process.platform === 'darwin') {
+      require('electron').ipcRenderer.on('touchbar', (event, message) => {
+        this.handleTouchbar(message)
+      })
+    }
+  }
   render() {
-    if (process.platform === 'darwin') {this.handleTouchbar(this.props.tbtriggered)}
     return (
       <div className='poi-control-container'>
         <OverlayTrigger placement='right' overlay={<Tooltip id='poi-developers-tools-button' className='poi-control-tooltip'>{__('Developer Tools')}</Tooltip>}>
@@ -270,23 +272,5 @@ const PoiControl = connect((state, props) => ({
     )
   }
 })
-
-//Touchbar input receiver
-if (process.platform === 'darwin') {
-  require('electron').ipcRenderer.on('touchbar', (event, message) => {
-    switch (message) {
-      //workaround for mute function is called twice
-    case 'volume':
-      if (config.get('poi.content.muted')){
-        config.set('poi.touchbar.triggered', 'unmute')
-      }
-      else {
-        config.set('poi.touchbar.triggered', 'mute')
-      }
-      break
-    default: config.set('poi.touchbar.triggered', message)
-    }
-  })
-}
 
 export { PoiControl }


### PR DESCRIPTION
TouchBar inputs are now stateless which:

1. Avoids abusing of <code>config</code>
1. Prevents unnecessary re-rendering
1. Decreases the number of times <code>handleTouchbar()</code> is called by half