### PR TITLE
Reduce white screen load time caused by plugins.

### DIFF
--- a/views/components/settings/parts/plugin-config.es
+++ b/views/components/settings/parts/plugin-config.es
@@ -584,8 +584,7 @@ const PluginConfig = connect((state, props) => ({
     }
   }
   componentDidMount = async () => {
-    PluginManager.initialize()
-    this.setState({
+      this.setState({
       checkingUpdate: true,
       npmWorking: true,
     })
@@ -823,6 +822,10 @@ const PluginConfig = connect((state, props) => ({
       </form>
     )
   }
+})
+
+remote.getCurrentWebContents().on('did-stop-loading', () => {
+  PluginManager.initialize()
 })
 
 export default PluginConfig

--- a/views/components/settings/parts/plugin-config.es
+++ b/views/components/settings/parts/plugin-config.es
@@ -584,6 +584,7 @@ const PluginConfig = connect((state, props) => ({
     }
   }
   componentDidMount = async () => {
+    PluginManager.initialize()
     this.setState({
       checkingUpdate: true,
       npmWorking: true,

--- a/views/components/settings/parts/plugin-config.es
+++ b/views/components/settings/parts/plugin-config.es
@@ -584,7 +584,7 @@ const PluginConfig = connect((state, props) => ({
     }
   }
   componentDidMount = async () => {
-      this.setState({
+    this.setState({
       checkingUpdate: true,
       npmWorking: true,
     })

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -436,8 +436,6 @@ const pluginManager = new PluginManager(
   join(ROOT, 'assets', 'data', 'mirror.json')
 )
 
-pluginManager.initialize()
-
 window.reloadPlugin = (pkgName, verbose=false) => {
   const { plugins } = getStore()
   const plugin =


### PR DESCRIPTION
Plugin manager would load plugin when module is loaded previously, and caused long time waiting on white screen if plugins are large in number. Now plugin list will load after dom component is loaded, and reduced waiting time on white screen almost by half (~12sec to ~6sec) when all available plugin is installed.
Wondering if anything will break after this change.