### PR TITLE
Refine the FP display

### DIFF
--- a/views/components/main/parts/minishipitem.es
+++ b/views/components/main/parts/minishipitem.es
@@ -216,7 +216,7 @@ export const MiniSquardRow = connect((state, { squardId }) =>
           </span>
           <span className="ship-lv-text top-space">
             <div className="ship-fp">
-              {__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + ' ~ ' + tyku.max}
+              {__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + '+'}
             </div>
             {statuslabel}
           </span>

--- a/views/components/main/parts/minishipitem.es
+++ b/views/components/main/parts/minishipitem.es
@@ -216,7 +216,7 @@ export const MiniSquardRow = connect((state, { squardId }) =>
           </span>
           <span className="ship-lv-text top-space">
             <div className="ship-fp">
-              {__('Fighter Power')}: {tyku.max}
+              {__('Fighter Power')}: {tyku.panel}
             </div>
             {statuslabel}
           </span>

--- a/views/components/main/parts/minishipitem.es
+++ b/views/components/main/parts/minishipitem.es
@@ -216,7 +216,7 @@ export const MiniSquardRow = connect((state, { squardId }) =>
           </span>
           <span className="ship-lv-text top-space">
             <div className="ship-fp">
-              {__('Fighter Power')}: {tyku.panel}
+              {__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + ' ~ ' + tyku.max}
             </div>
             {statuslabel}
           </span>

--- a/views/components/ship-parts/topalert.es
+++ b/views/components/ship-parts/topalert.es
@@ -167,7 +167,7 @@ export default connect(
         isMini ?
           <div style={{display: "flex", justifyContent: "space-around", width: '100%'}}>
             <span style={{flex: "none"}}>{__(getSpeedLabel(speed))} </span>
-            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {tyku.min}</span>
+            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + '+'}</span>
             <span style={{flex: "none", marginLeft: 5}}>{__('LOS')}: {saku33.total.toFixed(2)}</span>
           </div>
           :
@@ -183,7 +183,7 @@ export default connect(
                     <div>{__('Basic FP')}: {tyku.basic}</div>
                   </Tooltip>
                 }>
-                  <span>{__('Fighter Power')}: {tyku.min}</span>
+                  <span>{__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + '+'}</span>
                 </OverlayTrigger>
               </span>
               <span style={{flex: 1}}>

--- a/views/components/ship-parts/topalert.es
+++ b/views/components/ship-parts/topalert.es
@@ -167,7 +167,7 @@ export default connect(
         isMini ?
           <div style={{display: "flex", justifyContent: "space-around", width: '100%'}}>
             <span style={{flex: "none"}}>{__(getSpeedLabel(speed))} </span>
-            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {tyku.max}</span>
+            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {tyku.panel}</span>
             <span style={{flex: "none", marginLeft: 5}}>{__('LOS')}: {saku33.total.toFixed(2)}</span>
           </div>
           :
@@ -183,7 +183,7 @@ export default connect(
                     <div>{__('Basic FP')}: {tyku.basic}</div>
                   </Tooltip>
                 }>
-                  <span>{__('Fighter Power')}: {tyku.max}</span>
+                  <span>{__('Fighter Power')}: {tyku.panel}</span>
                 </OverlayTrigger>
               </span>
               <span style={{flex: 1}}>

--- a/views/components/ship-parts/topalert.es
+++ b/views/components/ship-parts/topalert.es
@@ -167,7 +167,7 @@ export default connect(
         isMini ?
           <div style={{display: "flex", justifyContent: "space-around", width: '100%'}}>
             <span style={{flex: "none"}}>{__(getSpeedLabel(speed))} </span>
-            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {tyku.panel}</span>
+            <span style={{flex: "none", marginLeft: 5}}>{__('Fighter Power')}: {tyku.min}</span>
             <span style={{flex: "none", marginLeft: 5}}>{__('LOS')}: {saku33.total.toFixed(2)}</span>
           </div>
           :
@@ -183,7 +183,7 @@ export default connect(
                     <div>{__('Basic FP')}: {tyku.basic}</div>
                   </Tooltip>
                 }>
-                  <span>{__('Fighter Power')}: {tyku.panel}</span>
+                  <span>{__('Fighter Power')}: {tyku.min}</span>
                 </OverlayTrigger>
               </span>
               <span style={{flex: 1}}>

--- a/views/components/ship/lbac-view.es
+++ b/views/components/ship/lbac-view.es
@@ -52,7 +52,7 @@ export const SquardRow = connect((state, { squardId }) =>
                 {__('Range')}: {api_distance}
               </span>
               <span className="ship-speed">
-                {__('Fighter Power')}: {tyku.max}
+                {__('Fighter Power')}: {tyku.panel}
               </span>
             </div>
           </div>

--- a/views/components/ship/lbac-view.es
+++ b/views/components/ship/lbac-view.es
@@ -51,7 +51,8 @@ export const SquardRow = connect((state, { squardId }) =>
               <span className='ship-lv'>
                 {__('Range')}: {api_distance}
               </span>
-              <span className="ship-speed">
+              <br />
+              <span className="ship-lv">
                 {__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + ' ~ ' + tyku.max}
               </span>
             </div>

--- a/views/components/ship/lbac-view.es
+++ b/views/components/ship/lbac-view.es
@@ -52,7 +52,7 @@ export const SquardRow = connect((state, { squardId }) =>
                 {__('Range')}: {api_distance}
               </span>
               <span className="ship-speed">
-                {__('Fighter Power')}: {tyku.panel}
+                {__('Fighter Power')}: {(tyku.max === tyku.min) ? tyku.min : tyku.min + ' ~ ' + tyku.max}
               </span>
             </div>
           </div>

--- a/views/utils/game-utils.es
+++ b/views/utils/game-utils.es
@@ -132,6 +132,7 @@ export function getTyku(equipsData, landbaseStatus=0) {
   let minTyku = 0
   let maxTyku = 0
   let basicTyku = 0
+  let panelTyku = 0
   let reconBonus = 1
   for (let i = 0; i < equipsData.length; i++) {
     if (!equipsData[i]) {
@@ -160,6 +161,7 @@ export function getTyku(equipsData, landbaseStatus=0) {
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
+        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       } else if ([11, 45].includes($equip.api_type[2])) {
@@ -167,6 +169,7 @@ export function getTyku(equipsData, landbaseStatus=0) {
         tempTyku += Math.sqrt(onslot) * $equip.api_tyku
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
+        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       } else if ([48].includes($equip.api_type[2])) {
@@ -177,6 +180,7 @@ export function getTyku(equipsData, landbaseStatus=0) {
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + landbaseBonus + (_equip.api_level || 0) * levelFactor)
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
+        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
       } else if ([10, 41].includes($equip.api_type[2]) && landbaseStatus == 2) {
@@ -200,6 +204,7 @@ export function getTyku(equipsData, landbaseStatus=0) {
   }
   return {
     basic: Math.floor(basicTyku * reconBonus),
+    panel: Math.floor(panelTyku * reconBonus),
     min: Math.floor(minTyku * reconBonus),
     max: Math.floor(maxTyku * reconBonus),
   }

--- a/views/utils/game-utils.es
+++ b/views/utils/game-utils.es
@@ -179,21 +179,33 @@ export function getTyku(equipsData, landbaseStatus=0) {
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-      } else if ([10, 41].includes($equip.api_type[2]) && landbaseStatus == 2) {
+      } else if ([10, 41].includes($equip.api_type[2])) {
         // 水偵・飛行艇
-        if ($equip.api_saku >= 9) {
-          reconBonus = Math.max(reconBonus, 1.16)
-        } else if ($equip.api_saku == 8) {
-          reconBonus = Math.max(reconBonus, 1.13)
-        } else {
-          reconBonus = Math.max(reconBonus, 1.1)
+        if (landbaseStatus == 2) {
+          if ($equip.api_saku >= 9) {
+            reconBonus = Math.max(reconBonus, 1.16)
+          } else if ($equip.api_saku == 8) {
+            reconBonus = Math.max(reconBonus, 1.13)
+          } else {
+            reconBonus = Math.max(reconBonus, 1.1)
+          }
+        } else if (landbaseStatus == 1) {
+          tempTyku += Math.sqrt(onslot) * $equip.api_tyku
+          minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
+          maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
         }
       } else if ([9].includes($equip.api_type[2]) && landbaseStatus == 2) {
         // 艦偵
-        if ($equip.api_saku >= 9) {
-          reconBonus = Math.max(reconBonus, 1.3)
-        } else {
-          reconBonus = Math.max(reconBonus, 1.2)
+        if (landbaseStatus == 2) {
+          if ($equip.api_saku >= 9) {
+            reconBonus = Math.max(reconBonus, 1.3)
+          } else {
+            reconBonus = Math.max(reconBonus, 1.2)
+          }
+        } else if (landbaseStatus == 1) {
+          tempTyku += Math.sqrt(onslot) * $equip.api_tyku
+          minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
+          maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
         }
       }
     }

--- a/views/utils/game-utils.es
+++ b/views/utils/game-utils.es
@@ -132,7 +132,6 @@ export function getTyku(equipsData, landbaseStatus=0) {
   let minTyku = 0
   let maxTyku = 0
   let basicTyku = 0
-  let panelTyku = 0
   let reconBonus = 1
   for (let i = 0; i < equipsData.length; i++) {
     if (!equipsData[i]) {
@@ -161,17 +160,15 @@ export function getTyku(equipsData, landbaseStatus=0) {
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
+        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
       } else if ([11, 45].includes($equip.api_type[2])) {
         // 水上機
         tempTyku += Math.sqrt(onslot) * $equip.api_tyku
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
+        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
       } else if ([48].includes($equip.api_type[2])) {
         // 局戦 · 陸戦
         let landbaseBonus = 0
@@ -180,9 +177,8 @@ export function getTyku(equipsData, landbaseStatus=0) {
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + landbaseBonus + (_equip.api_level || 0) * levelFactor)
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        panelTyku += Math.floor(tempTyku + Math.sqrt((tempAlv === 0) ? 0 : aircraftExpTable[tempAlv + 1] / 10))
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv + 1] / 10))
+        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
       } else if ([10, 41].includes($equip.api_type[2]) && landbaseStatus == 2) {
         // 水偵・飛行艇
         if ($equip.api_saku >= 9) {
@@ -204,7 +200,6 @@ export function getTyku(equipsData, landbaseStatus=0) {
   }
   return {
     basic: Math.floor(basicTyku * reconBonus),
-    panel: Math.floor(panelTyku * reconBonus),
     min: Math.floor(minTyku * reconBonus),
     max: Math.floor(maxTyku * reconBonus),
   }


### PR DESCRIPTION
The AP shown on panels currently is the Max FP by default. It works well on most of the situations, but not on the case that there are aircrafts with 0 proficiency level. A 0-level (no label) aircraft usually means "a new aircraft" or "a totally destroyed squadron", and users may be confused with or even mislead by the larger than expected FP.  

This PR will make the FP shown on panel to exclude the internal proficiency bonus of a 0-level aircraft. The Max and Min FP is still available through the tooltip.