### PR TITLE
keep $shipUpgrades intact instead of indexifying it

### DIFF
--- a/views/redux/const.es
+++ b/views/redux/const.es
@@ -12,7 +12,12 @@ function dataFromBody(body) {
     $missions: indexify(body.api_mst_mission),
     $useitems: indexify(body.api_mst_useitem),
     $shipgraph: body.api_mst_shipgraph,
-    $shipUpgrades: indexify(body.api_mst_shipupgrade),
+    /*
+       IMPORTANT: do not indexify api_mst_shipupgrade,
+       because api_id does not suggest uniqueness in this part
+       due to having cyclic remodel chains.
+     */
+    $shipUpgrades: body.api_mst_shipupgrade,
     $exslotEquips: body.api_mst_equip_exslot,
     $exslotEquipShips: keyBy(body.api_mst_equip_exslot_ship, 'api_slotitem_id'),
   }


### PR DESCRIPTION
turns out `api_id` indicates ship master id **after remodeling**. due to having cyclic remodel chains in game, `api_id` is not unique among elements in `api_mst_shipupgrade`.

so I think the best we can do is to keep it intact and let developers using it decide what to do.

the name is still `$shipUpgrades`, as it's easy to distinguish Array from Object and there are no other packages using this except navy album, I think this is not a big problem.

p.s. however `api_current_ship_id` is unique if you take out every  `api_current_ship_id = 0` values. because there is no branched remodeling in game ~~yet~~.