### PR TITLE
Use local shortcuts

### DIFF
--- a/lib/shortcut.es
+++ b/lib/shortcut.es
@@ -20,18 +20,11 @@ const registerBossKey = () => {
     if (!registerShortcut(accelerator, 'Boss Key', windowManager.toggleAllWindowsVisibility))
       config.set('poi.shortcut.bosskey', '')
 }
-const registerDevToolShortcut = () => {
-  const accelerator = 'Ctrl+Shift+I'
-  registerShortcut(accelerator, 'Open Focused Window Dev Tools', windowManager.openFocusedWindowDevTools)
-}
 
 export default {
   register: () => {
     if (process.platform !== 'darwin') {
       registerBossKey()
-    }
-    if (config.get('poi.shortcut.useGlobalDevToolShortCut', false)){
-      registerDevToolShortcut()
     }
   },
   unregister: () => {

--- a/lib/shortcut.es
+++ b/lib/shortcut.es
@@ -30,7 +30,9 @@ export default {
     if (process.platform !== 'darwin') {
       registerBossKey()
     }
-    registerDevToolShortcut()
+    if (config.get('poi.shortcut.useGlobalDevToolShortCut', false)){
+      registerDevToolShortcut()
+    }
   },
   unregister: () => {
     globalShortcut.unregisterAll()

--- a/views/components/etc/menu.es
+++ b/views/components/etc/menu.es
@@ -303,7 +303,7 @@ if (process.platform !== 'darwin') {
         { type: 'separator' },
         {
           label: __ ('Developer Tools'),
-          accelerator: 'Alt+CmdOrCtrl+I',
+          accelerator: 'Cmd+Shift+I',
           click: (item, focusedWindow) => {
             focusedWindow.openDevTools({detach: true})
           },

--- a/views/components/etc/menu.es
+++ b/views/components/etc/menu.es
@@ -97,8 +97,9 @@ if (process.platform !== 'darwin') {
         },
         {
           label: __('Developer Tools'),
+          accelerator: 'Ctrl+Shift+I',
           click: (item, focusedWindow) => {
-            remote.getGlobal('mainWindow').openDevTools({detach: true})
+            focusedWindow.openDevTools({detach: true})
           },
         },
         {
@@ -410,7 +411,7 @@ for (let i = window.normalThemes.length - 1; i >=0; i--) {
   })
 }
 
-const appMenu = Menu.buildFromTemplate(template)
+export const appMenu = Menu.buildFromTemplate(template)
 if (process.platform === 'darwin') {
   Menu.setApplicationMenu(appMenu)
 } else {

--- a/views/services/plugin-manager-utils.es
+++ b/views/services/plugin-manager-utils.es
@@ -319,6 +319,9 @@ const postEnableProcess = (plugin) => {
     if (plugin.multiWindow) {
       plugin.handleClick = function() {
         const pluginWindow = windowManager.createWindow(windowOptions)
+        pluginWindow.setMenu(require('views/components/etc/menu').appMenu)
+        pluginWindow.setAutoHideMenuBar(true)
+        pluginWindow.setMenuBarVisibility(false)
         pluginWindow.loadURL(plugin.windowURL)
         pluginWindow.show()
       }
@@ -327,6 +330,9 @@ const postEnableProcess = (plugin) => {
       plugin.handleClick = function() {
         if (plugin.pluginWindow == null) {
           plugin.pluginWindow = windowManager.createWindow(windowOptions)
+          plugin.pluginWindow.setMenu(require('views/components/etc/menu').appMenu)
+          plugin.pluginWindow.setAutoHideMenuBar(true)
+          plugin.pluginWindow.setMenuBarVisibility(false)
           plugin.pluginWindow.on('close', function() {
             plugin.pluginWindow = null
           })
@@ -338,6 +344,9 @@ const postEnableProcess = (plugin) => {
       }
     } else {
       plugin.pluginWindow = windowManager.createWindow(windowOptions)
+      plugin.pluginWindow.setMenu(require('views/components/etc/menu').appMenu)
+      plugin.pluginWindow.setAutoHideMenuBar(true)
+      plugin.pluginWindow.setMenuBarVisibility(false)
       plugin.pluginWindow.loadURL(plugin.windowURL)
       plugin.handleClick = function() {
         return plugin.pluginWindow.show()


### PR DESCRIPTION
This PR will use local keyboard shortcut to toggle devtools instead of using global shortcut. 
Fixes #1557.
The legacy global shortcuts is not yet removed and can be reenable by set `poi.shortcut.useGlobalDevToolShortCut` to `true`