### PR TITLE
move screeshot & plugin list to wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,10 @@ brew update && brew cask install poi
 ## Screenshots
 
 ![Preview 1](https://cloud.githubusercontent.com/assets/6753092/10863967/ebcc2b60-8018-11e5-9f74-9d0cf214fe49.png)
+
 ![Preview 2](https://cloud.githubusercontent.com/assets/6753092/10863968/ee4d8a96-8018-11e5-92ae-7f794864dca8.png)
-![Preview 3](https://cloud.githubusercontent.com/assets/6753092/10863969/f0a49b2c-8018-11e5-9659-43f626c4691c.png)
-![Preview 4](https://cloud.githubusercontent.com/assets/6753092/10863970/f19f7ec0-8018-11e5-99f8-8df3bced1616.png)
-![Preview 5](https://cloud.githubusercontent.com/assets/6753092/10863971/f2a69114-8018-11e5-8b4e-3017472a24a4.png)
-![Preview 6](https://cloud.githubusercontent.com/assets/6753092/10863972/f3c3a898-8018-11e5-9aa6-0049a879e0bc.png)
-![Preview 7](https://cloud.githubusercontent.com/assets/6753092/10863973/f56bddb4-8018-11e5-82c1-4d1fc23779a8.png)
-![Preview 8](https://cloud.githubusercontent.com/assets/6753092/10863975/f70264ae-8018-11e5-8b71-2fb9a78819d5.png)
-![Preview 9](https://cloud.githubusercontent.com/assets/6753092/10863976/f8458094-8018-11e5-9164-c9127fee9257.png)
+
+[More screenshots are available here](https://github.com/poooi/poi/wiki/Screenshots)
 
 ## Run from dev version
 
@@ -62,62 +58,7 @@ Tips:
 - If you have trouble downloading electron executables from github/amazonaws, [you may set ELECTRON_MIRROR environment variable](https://github.com/electron-userland/electron-download).
 
 ## Available Plugins
-[plugin-prophet](https://github.com/poooi/plugin-prophet) by [Chiba](https://github.com/Chibaheit)
-> Show the result of battle.
-
-[plugin-exp-calculator](https://github.com/poooi/plugin-exp-calculator) by [Chiba](https://github.com/Chibaheit)
-> Calculate experience value.
-
-[plugin-map-hp](https://github.com/poooi/plugin-map-hp) by [Chiba](https://github.com/Chibaheit)
-> a plugin map hp for poi.
-
-[plugin-report](https://github.com/poooi/plugin-report) by [Magica](https://github.com/magicae)
-> Report ship creating info and drop info, and so on.
-
-[plugin-expedition](https://github.com/poooi/plugin-expedition) by [Malichan](https://github.com/malichan)
-> Show expedition info.
-
-[plugin-quest](https://github.com/poooi/plugin-quest) by [Malichan](https://github.com/malichan)
-> Show quest info.
-
-[plugin-item-improvement](https://github.com/poooi/plugin-item-improvement) by [KochiyaOcean](https://github.com/KochiyaOcean)
-> Show improvable items of the day.
-
-[plugin-ship-info](https://github.com/poooi/plugin-ship-info) by [Yunze](https://github.com/myzwillmake)
-> Show detailed information of all owned ships.
-
-[plugin-item-info](https://github.com/poooi/plugin-item-info) by [Yunze](https://github.com/myzwillmake)
-> Show information of all owned items.
-
-[plugin-new-window](https://github.com/poooi/plugin-new-window) by [KochiyaOcean](https://github.com/KochiyaOcean)
-> Open a external browser window.
-
-[plugin-Akashic-records](https://github.com/poooi/plugin-Akashic-records) by [JenningsWu](https://github.com/JenningsWu)
-> Logbook plugin for poi.
-
-[plugin-battle-detail](https://github.com/poooi/plugin-battle-detail) by [Dazzy Ding](https://github.com/yukixz)
-> Show battle detail.
-
-[plugin-hensei-nikki](https://github.com/poooi/plugin-hensei-nikki.git) by [Rui](https://github.com/ruiii)
-> Record fleet config once sortied.
-
-[plugin-almanac](https://github.com/poooi/plugin-almanac) by [Magica](https://github.com/magicae)
-> KanColle almanac from http://sandbox.runjs.cn/show/x9ou86rn
-
-[plugin-repair](https://github.com/Ayaphis/plugin-repair) by [Ayaphis](https://github.com/Ayaphis)
-> Calculate the time required of repair.
-
-[plugin-secretary](https://github.com/dazzyd/poi-secretary) by [Dazzy Ding](https://github.com/yukixz)
-> Use secretary voice as notification sound.
-
-[plugin-hairstrength](https://github.com/ruiii/plugin-hairstrength.git) by [Rui](https://github.com/ruiii)
-> Senka calculator.
-
-[plugin-anchorage-repair](https://github.com/KagamiChan/plugin-anchorage-repair.git) by [かがみ](https://github.com/KagamiChan)
-> Helper for akashi repair
-
-[plugin-ezexped](https://github.com/poooi/poi-plugin-ezexped) by [Javran](https://github.com/Javran)
-> Expedition made easy
+Many functionalities are provided as plugins, you may choose only what you want! [Here's a list of available plugins](https://github.com/poooi/poi/wiki/List-of-available-plugins).
 
 ## Contributing
 


### PR DESCRIPTION
to shorten the readme and make opencollective more visible