### PR TITLE
fix ci npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ language: c
 matrix:
   include:
     - os: osx
+      env: TRAVIS_NODE_VERSION="8.4.0"
     - os: linux
-      env: CC=clang CXX=clang++ npm_config_clang=1 TRAVIS_NODE_VERSION="7.7.4"
+      env: CC=clang CXX=clang++ npm_config_clang=1 TRAVIS_NODE_VERSION="8.4.0"
       compiler: clang
 
 addons:
@@ -29,8 +30,8 @@ cache:
 
 install:
   - nvm install $TRAVIS_NODE_VERSION
-  - nvm use 7
-  - npm install -g npm@latest
+  - nvm use 8
+  - npm install -g npm@5.3.0
   - npm install --silent
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 7 x64
+  - ps: Install-Product node 8 x64
   - git reset --hard HEAD
-  - npm install npm@latest -g
+  - npm install npm@5.3.0 -g
   - npm install --silent
   - npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "7zip-bin-win": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.0.tgz",
-      "integrity": "sha512-7t8V+cGvZ0xUAuTLH1iDkrl+XVYWxlS3hHCvA6yELTcx2VwgMDNe4FdQlyKJRjO0PExn0sit8wD3PGaPKBpt2A==",
-      "dev": true,
-      "optional": true
-    },
     "@exponent/electron-cookies": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@exponent/electron-cookies/-/electron-cookies-2.0.0.tgz",
@@ -25,6 +18,20 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",
       "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ==",
       "dev": true
+    },
+    "7zip-bin-linux": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.1.0.tgz",
+      "integrity": "sha512-BfW7XsUWNV/j723el3gGbiNWdmvLrnTB9VD0BondfCinxCwz4RQ60W4c3UxRpfHn1Q4Cn1o/DxYFmLMgHTEKqg==",
+      "dev": true,
+      "optional": true
+    },
+    "7zip-bin-win": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.0.tgz",
+      "integrity": "sha512-7t8V+cGvZ0xUAuTLH1iDkrl+XVYWxlS3hHCvA6yELTcx2VwgMDNe4FdQlyKJRjO0PExn0sit8wD3PGaPKBpt2A==",
+      "dev": true,
+      "optional": true
     },
     "abbrev": {
       "version": "1.1.0",
@@ -1897,7 +1904,18 @@
           "integrity": "sha512-S2f7InK2SwceVFly0tx/+1xakOWhSZQeY5hOXFl/sZ9orfRE4i4Z9edsWonT5lyYTowBN73RwBbLqZaVrtSEuw==",
           "dev": true,
           "requires": {
+            "7zip-bin-linux": "1.1.0",
+            "7zip-bin-mac": "1.0.1",
             "7zip-bin-win": "2.1.0"
+          },
+          "dependencies": {
+            "7zip-bin-mac": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
+              "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "ajv": {
@@ -5267,7 +5285,6 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.4.0.tgz",
       "integrity": "sha512-jw7Gq2dMM3RWBUaQmuJTB/dcZEiTL2c6VUrXvlWU/37SXR0GCCGysKfwQcjQerTmmrycIpfLZS2msHa26FsAKQ==",
       "requires": {
-        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -5297,6 +5314,7 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
+        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.6.0",
         "lockfile": "1.0.3",
@@ -5367,24 +5385,6 @@
         "write-file-atomic": "2.3.0"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -5681,6 +5681,24 @@
               "requires": {
                 "read": "1.0.7"
               }
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
             }
           }
         },
@@ -9744,6 +9762,11 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
@@ -9759,11 +9782,6 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "start_debug": "electron . --dev",
     "dev": "electron . --dev",
     "clean": "gulp clean",
-    "lint": "eslint . --ext .es --ext .js --ignore-path .gitignore",
-    "postinstall": "opencollective postinstall"
+    "lint": "eslint . --ext .es --ext .js --ignore-path .gitignore"
   },
   "repository": {
     "type": "git",
@@ -64,7 +63,6 @@
     "mousetrap": "^1.5.3",
     "npm": "^5.4.0",
     "objtree": "^0.1.1",
-    "opencollective": "^1.0.3",
     "pac-proxy-agent": "^2.0.0",
     "path-extra": "^4.2.0",
     "poi-asset-themes": "^3.2.0",


### PR DESCRIPTION
- removed opencollective dependencies because our end users could not notice it.
- avoid npm 5.4.0 permission bug that keeps ci on Linux and macOS failing https://github.com/npm/npm/issues/18324

