### PR TITLE
Seaplane fighter gains improvement benefits

### DIFF
--- a/views/utils/game-utils.es
+++ b/views/utils/game-utils.es
@@ -166,15 +166,15 @@ export function getTyku(equipsData, landbaseStatus=0) {
       }
       // 改修：艦戦×0.2、爆戦×0.25
       const levelFactor = $equip.api_baku > 0 ? 0.25 : 0.2
-      if ([6, 7, 8, 47, 56, 57, 58].includes($equip.api_type[2])) {
-        // 艦载機 · 陸上攻撃機 · 噴式機
+      if ([6, 7, 8, 45, 47, 56, 57, 58].includes($equip.api_type[2])) {
+        // 艦载機 · 水上戦闘機 · 陸上攻撃機 · 噴式機
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
         minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
         maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-      } else if ([11, 45].includes($equip.api_type[2])) {
-        // 水上機
+      } else if ([11].includes($equip.api_type[2])) {
+        // 水上爆撃機
         tempTyku += Math.sqrt(onslot) * $equip.api_tyku
         tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
         basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)


### PR DESCRIPTION
As for the effect of improvement, a seaplane fighter gains ★×0.2 AA bonus like a carrier-based fighter.

Source: [改修総合スレッド | 艦これ検証Wiki | FANDOM powered by Wikia](http://ja.kancolle.wikia.com/wiki/%E3%82%B9%E3%83%AC%E3%83%83%E3%83%89:951#42)