### PR TITLE
Feature: reset / repair plugin directory

### DIFF
--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -125,6 +125,7 @@
   "Select npm server": "NPM サーバーを選択する",
   "Open plugin folder": "プラグインのフォルダを開く",
   "Search for plugins": "プラグインを検索する",
+  "Repair plugins": "自動修復",
   "Connect to npm server through proxy": "プロキシサーバ経由て NPM サーバーに接続する",
   "Developer option: check update of beta version": "開発者向けオプション: プラグインのベータ版を確認する",
   "Automatically update plugins": "プラグインを自動に更新する",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -125,6 +125,7 @@
   "Select npm server": "选择 npm 服务器",
   "Open plugin folder": "打开插件目录",
   "Search for plugins": "查找插件",
+  "Repair plugins": "自动修复",
   "Connect to npm server through proxy": "使用代理连接至 npm 服务器",
   "Developer option: check update of beta version": "开发者选项: 检查 beta 版插件更新",
   "Automatically update plugins": "自动更新插件",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -125,6 +125,7 @@
   "Select npm server": "選擇 npm 伺服器",
   "Open plugin folder": "開啟擴展程式目錄",
   "Search for plugins": "尋找擴展程式",
+  "Repair plugins": "自動修復",
   "Connect to npm server through proxy": "使用代理連線至 npm 伺服器",
   "Developer option: check update of beta version": "開發者選項: 檢查 beta 版擴展程式更新",
   "Automatically update plugins": "自動更新擴展程式",

--- a/views/components/settings/plugin/index.es
+++ b/views/components/settings/plugin/index.es
@@ -241,6 +241,13 @@ const PluginConfig = connect((state, props) => ({
       this.setState({manuallyInstallStatus: 3})
     }
   }
+  handleGracefulReset = async () => {
+    try {
+      await PluginManager.gracefulReset()
+    } catch (e) {
+      console.error(e)
+    }
+  }
   synchronize = (callback) => {
     if (this.lock) {
       return
@@ -461,11 +468,14 @@ const PluginConfig = connect((state, props) => ({
                         </div>
                         <Row>
                           <ButtonGroup className='plugin-buttongroup'>
-                            <Button className='col-xs-6' onClick={this.onSelectOpenFolder}>
+                            <Button className='col-xs-4' onClick={this.onSelectOpenFolder}>
                               {__('Open plugin folder')}
                             </Button>
-                            <Button className='col-xs-6' onClick={this.onSelectOpenSite}>
+                            <Button className='col-xs-4' onClick={this.onSelectOpenSite}>
                               {__('Search for plugins')}
+                            </Button>
+                            <Button className='col-xs-4' onClick={this.handleGracefulReset}>
+                              {__('Reset plugins')}
                             </Button>
                           </ButtonGroup>
                         </Row>

--- a/views/components/settings/plugin/index.es
+++ b/views/components/settings/plugin/index.es
@@ -167,11 +167,11 @@ const PluginConfig = connect((state, props) => ({
       const plugins = PluginManager.getInstalledPlugins()
       const plugin = plugins[index]
       await PluginManager.uninstallPlugin(plugin)
-      this.setState({npmWorking: false})
     }
     catch (error) {
-      this.setState({npmWorking: false})
       throw error
+    } finally {
+      this.setState({npmWorking: false})
     }
   }
   checkUpdate = async () =>{
@@ -241,11 +241,18 @@ const PluginConfig = connect((state, props) => ({
       this.setState({manuallyInstallStatus: 3})
     }
   }
-  handleGracefulReset = async () => {
+  handleGracefulRepair = async () => {
+    this.setState({
+      npmWorking: true,
+    })
     try {
-      await PluginManager.gracefulReset()
+      await PluginManager.gracefulRepair()
     } catch (e) {
       console.error(e)
+    } finally {
+      this.setState({
+        npmWorking: false,
+      })
     }
   }
   synchronize = (callback) => {
@@ -474,8 +481,8 @@ const PluginConfig = connect((state, props) => ({
                             <Button className='col-xs-4' onClick={this.onSelectOpenSite}>
                               {__('Search for plugins')}
                             </Button>
-                            <Button className='col-xs-4' onClick={this.handleGracefulReset}>
-                              {__('Reset plugins')}
+                            <Button className='col-xs-4' onClick={this.handleGracefulRepair}>
+                              {__('Repair plugins')}
                             </Button>
                           </ButtonGroup>
                         </Row>


### PR DESCRIPTION
This PR introduces a functionality to completely remove and reinstall all plugins. It is considered helpful for solving plugin dependency compat problem for users upgrading from legacy versions.

Added a `window.gracefulResetPlugin()` shortcut to help user completely remove the directory

Minor code changes:
- move loading mirrors and configs to `PluginManager`'s `constructor` part