### PR TITLE
Feat: set accept-language header with DMM cookies enabled

### DIFF
--- a/views/services.es
+++ b/views/services.es
@@ -174,6 +174,8 @@ remote.getCurrentWebContents().on('dom-ready', () => {
         document.cookie = "ckcy=1;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=.dmm.com;path=/netgame/";
         document.cookie = "ckcy=1;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=.dmm.com;path=/netgame_s/";
       `)
+      const ua = $('kan-game webview').getWebContents().session.getUserAgent()
+      $('kan-game webview').getWebContents().session.setUserAgent(ua, 'ja-JP')
     }
     if (config.get('poi.disableNetworkAlert', false)) {
       $('kan-game webview').executeJavaScript('DMM.netgame.reloadDialog=function(){}')


### PR DESCRIPTION
It is found that DMM will redirect requests from US IP with `accept-language` header set as `zh-CN`, but using `en-US` or `ja-JP` is OK