### PR TITLE
Tracking new quests & update to quest DSL

### DIFF
--- a/assets/data/quest_goal.cson
+++ b/assets/data/quest_goal.cson
@@ -267,7 +267,7 @@ for more details see views/redux/quests.es
   type: 2
   "destory_item":
     description: "廃棄"
-    slotitemId: [15]
+    slotitemType2: [21] # 21=対空機銃
     required: 6
     init: 0
 ###
@@ -347,11 +347,11 @@ for more details see views/redux/quests.es
     mission: ['長時間対潜警戒']
     init: 0
 
-663: #新型艤装の継続研究
+663: #新型艤装の継続研究 (大口径主砲を10個廃棄)
   type: 4
   "destory_item":
     description: "廃棄"
-    slotitemId: [3]
+    slotitemType2: [3] # 3=大口径主砲
     required: 10
     init: 0
 

--- a/assets/data/quest_goal.cson
+++ b/assets/data/quest_goal.cson
@@ -117,12 +117,27 @@ for more details see views/redux/quests.es
     description: "改修"
     required: 1
     init: 0
+673: # 装備開発力の整備 (「小口径主砲」系装備x4を廃棄)
+  type: 1
+  "destory_item":
+    description: "廃棄"
+    slotitemType2: [1] # 1=小口径主砲
+    required: 4
+    init: 0
+674: # 工廠環境の整備 (「機銃」系装備x3を廃棄)
+  type: 1
+  "destory_item":
+    description: "廃棄"
+    slotitemType2: [21] # 21=対空機銃
+    required: 3
+    init: 0
 702: # 艦の「近代化改修」を実施せよ！ 近代化改修2次
   type: 1
   "remodel_ship":
     description: "近代化改修"
     required: 2
     init: 0
+
 ###
 # Someday
 ###

--- a/views/redux/info/quests.es
+++ b/views/redux/info/quests.es
@@ -209,7 +209,7 @@ function updateQuestRecordFactory(records, activeQuests, questGoals) {
         if (!satisfyGoal('shipType', subgoal, options)) return
         if (!satisfyGoal('mission', subgoal, options)) return
         if (!satisfyGoal('maparea', subgoal, options)) return
-        if (!satisfyGoal('slotitemId', subgoal, options)) return
+        if (!satisfyGoal('slotitemType2', subgoal, options)) return
         if (!satisfyGoal('times', subgoal, options)) return
         const subrecord = Object.assign({}, record[_event])
         subrecord.count = Math.min(subrecord.required, subrecord.count + delta)
@@ -340,15 +340,15 @@ function questTrackingReducer(state, {type, postBody, body, result}) {
     // e.g. api_slotitem_ids = "24004,24020"
     const slotitems = postBody.api_slotitem_ids || ''
     const ids = slotitems.split(',')
-    // now it only supports gun quest, slotitemId = $ietm.api_type[3]
+    // now it only supports gun quest, slotitemType2 = $item.api_type[2]
     const typeCounts = countBy(ids, id => {
       const equipId = getStore(`info.equips.${id}.api_slotitem_id`)
-      return getStore(`const.$equips.${equipId}.api_type.3`)
+      return getStore(`const.$equips.${equipId}.api_type.2`)
     })
 
     let flag = false
-    forEach(Object.keys(typeCounts), slotitemId => {
-      flag = flag || updateQuestRecord('destory_item', {slotitemId: +slotitemId}, typeCounts[slotitemId])
+    forEach(Object.keys(typeCounts), slotitemType2 => {
+      flag = flag || updateQuestRecord('destory_item', {slotitemType2: +slotitemType2}, typeCounts[slotitemType2])
     })
 
     if (updateQuestRecord('destory_item', {times: 1}, 1)|| flag) {


### PR DESCRIPTION
- update to quest DSL:
    originally `slotitemId` (api_type[3]) is used, which actually stands for icon ids,
    which makes it inconvenient in some cases
    (e.g.  small calibre guns have two different icons, one of them is shared with high-angle mounts
    which does not necessarily fall into small calibre category)
    instead DSL is modified to use `slotitemType2` (api_type[2]).
    Related quests are updated accordingly as well.

- tracking new daily quests (tested locally)