### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,11 +176,18 @@
         "github"
       ],
       "target": [
+        "snap",
         "7z",
         "deb",
         "rpm",
         "pacman",
         "AppImage"
+      ]
+    },
+    "snap": {
+      "plugs": [
+        "default",
+        "desktop"
       ]
     },
     "directories": {


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04 and 17.10, but it should work just as well on Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run build -- -l` it will create `dist/poi_8.1.0-beta.0_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous poi_8.1.0-beta.0_amd64.snap`

Run with `poi` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "poi" name](https://dashboard.snapcraft.io/register-snap/?name=poi).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push poi out with:
`snapcraft push poi_8.1.0-beta.0_amd64.snap --release stable`

(You can also push to the Snap Store [programmatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)

Signed-off-by: Evan Dandrea \<evan@dandrea.co.uk\>