### PR TITLE
Update docking-related info more closely

### DIFF
--- a/views/create-store.es
+++ b/views/create-store.es
@@ -7,6 +7,7 @@ import { remote } from 'electron'
 import { middleware as promiseActionMiddleware } from './middlewares/promise-action'
 import { reducerFactory, onConfigChange } from './redux'
 import { saveQuestTracking, schedualDailyRefresh } from './redux/info/quests'
+import { dockingCompleteObserver } from './redux/info/repairs'
 import { dispatchBattleResult } from './redux/battle'
 
 const cachePosition = '_storeCache'
@@ -147,3 +148,7 @@ export const extendReducer = (function () {
 window.config.get = (path, value) => {
   return get(window.getStore('config'), path, value)
 }
+
+// observe on docking status and send an action to update info.ships
+// when docking is done.
+observe(store, [dockingCompleteObserver])

--- a/views/redux/info/repairs.es
+++ b/views/redux/info/repairs.es
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { compareUpdate } from 'views/utils/tools'
 import { observer } from 'redux-observers'
 
@@ -12,8 +13,6 @@ const emptyRepair = {
   api_ship_id: 0,
   api_state: 0,
 }
-
-import _ from 'lodash'
 
 export function reducer(state=[], {type, body, postBody}) {
   switch (type) {

--- a/views/redux/info/ships.es
+++ b/views/redux/info/ships.es
@@ -91,6 +91,13 @@ export function reducer(state={}, {type, body, postBody}) {
     }
     break
   }
+  case '@@info.ships@RepairCompleted': {
+    const {api_ship_id} = body
+    return {
+      ...state,
+      [api_ship_id]: completeRepair(state[api_ship_id]),
+    }
+  }
   }
   return state
 }

--- a/views/redux/info/ships.es
+++ b/views/redux/info/ships.es
@@ -2,6 +2,49 @@ import {values} from 'lodash'
 
 import { compareUpdate, indexify, pickExisting } from 'views/utils/tools'
 
+/*
+
+   turns out if it takes less than 60 seconds to repair a ship,
+   the following will happen:
+
+   - kcsapi/api_req_nyukyo/start is requested
+   - kcsapi/api_get_member/ndock is requested right after previous request is done,
+     but in the response body, the corresponding slot does not contain any ship
+     and is marked as available (api_state === 0) as if the docking never happened.
+     simply observing changes to info.repairs will not help in this case,
+     as the ship being docked is never included in the response body.
+
+   we call this scenario "instant docking completion".
+
+   to handle this scenario correctly,
+   an internal state (could be null) of the following shape is used for detection:
+
+   instantDockingCompletionState = {
+     dockId: <number from 1 to 4>,
+     rstId: <ship roster id>,
+   }
+
+   - initially, the state is set to `null`.
+
+   - any docking action (i.e. kcsapi/api_req_nyukyo/start) sets it accordingly.
+
+   - any kcsapi/api_get_member/ndock request sets it back to `null` after state
+     transition is handled.
+
+   - as `kcsapi/api_req_nyukyo/start` is always followed by `kcsapi/api_get_member/ndock`,
+     this internal state can only be non-null after `kcsapi/api_req_nyukyo/start` and
+     before finishing handling `kcsapi/api_get_member/ndock`.
+
+   - while handling `kcsapi/api_get_member/ndock`, we check whether the dock we just used
+     is empty, and if it's indeed the case, that indicates instant docking completion is happening
+     so we apply repair accordingly.
+
+   justification for using an internal state instead of keeping it in redux store:
+   the transition is short, and no other part cares about this particular part of state.
+
+ */
+let instantDockingCompletionState = null
+
 // Restore a ship with full health and >=40 cond.
 // Returns a clone.
 function completeRepair(ship) {
@@ -73,13 +116,34 @@ export function reducer(state={}, {type, body, postBody}) {
       [body.api_ship.api_id]: body.api_ship,
     }
   case '@@Response/kcsapi/api_req_nyukyo/start': {
-    const {api_ship_id, api_highspeed} = postBody
+    const {api_ship_id, api_highspeed, api_ndock_id} = postBody
+    instantDockingCompletionState = {
+      rstId: api_ship_id,
+      dockId: Number(api_ndock_id),
+    }
+
     if (api_highspeed == '1')
       return {
         ...state,
         [api_ship_id]: completeRepair(state[api_ship_id]),
       }
     break
+  }
+  case '@@Response/kcsapi/api_get_member/ndock': {
+    let newState = state
+    if (instantDockingCompletionState) {
+      const {rstId, dockId} = instantDockingCompletionState
+      const dockInfo = body.find(x => x.api_id === dockId)
+      if (dockInfo.api_ship_id === 0) {
+        newState = {
+          ...state,
+          [rstId]: completeRepair(state[rstId]),
+        }
+      }
+    }
+
+    instantDockingCompletionState = null
+    return newState
   }
   case '@@Response/kcsapi/api_req_nyukyo/speedchange': {
     const api_ship_id = getStore(`info.repair.${postBody.api_ndock_id}.api_ship_id`)


### PR DESCRIPTION
This patch brings in 2 changes:

- docking completion without using instant repair item updates `info.ships` accordingly.
- deal with "instant docking completion". simply put, when docking time is less than 60 seconds,
  we cannot detect docking completion by observing changes to `info.repairs`. the solution to this is 
 explained in [my comment](https://github.com/Javran/poi/blob/66f66457cc834fc9ab6225e0772dc70e5857cf8a/views/redux/info/ships.es#L5-L45). please check it out for more details.

Fixes https://github.com/Javran/poi-plugin-docking/issues/3