### PR TITLE
Implement window.pluginHelper to replace window.reloadPlugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,15 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     'no-console': ['warn', {'allow': ['warn', 'error']}],
     'no-var': 'error',
-    'no-unused-vars': ['warn', {'args': 'none'}],
+    'no-unused-vars':
+      [
+        'warn',
+        {
+          'vars': 'all',
+          'varsIgnorePattern': '^_[a-zA-Z].*',
+          'args': 'none',
+        }
+      ],
     'semi': ['error', 'never'],
     'unicode-bom': 'error',
     'prefer-const': ['error', {'destructuring': 'all'}],

--- a/views/create-store.es
+++ b/views/create-store.es
@@ -9,6 +9,7 @@ import { reducerFactory, onConfigChange } from './redux'
 import { saveQuestTracking, schedualDailyRefresh } from './redux/info/quests'
 import { dockingCompleteObserver } from './redux/info/repairs'
 import { dispatchBattleResult } from './redux/battle'
+import { pluginHelperObserver } from './services/plugin-helper'
 
 const cachePosition = '_storeCache'
 const targetPaths = ['const', 'info', 'fcd', 'wctf']
@@ -123,6 +124,8 @@ observe(store, compact([
   // observe on docking status and send an action to update info.ships
   // when docking is done.
   dockingCompleteObserver,
+
+  window.isMain && pluginHelperObserver,
 ]))
 
 schedualDailyRefresh(store.dispatch)

--- a/views/services/plugin-helper.es
+++ b/views/services/plugin-helper.es
@@ -1,0 +1,138 @@
+/*
+   pluginHelper is a tool that provides convenient access to
+   plugin-related operations and information.
+
+   - window.pluginHelper.$reload(pkgNameOrShort, verbose=false, measureEnableTime=true)
+
+       reload a plugin.
+
+       pkgNameOrShort: full package name or the string after prefix 'poi-plugin-'
+       verbose: bool, verbosity control
+       measureEnableTime: bool, whether time duration of enabling a plugin should be printed
+
+   - window.pluginHelper.$populate()
+
+       most of the time you don't have to call this function, as it's called automatically by observer
+       whenever the list of plugin changes.
+
+       clear and reload all `window.pluginHelper.<pkgNameOrShort>` (see below)
+
+   - window.pluginHelper.<pkgNameOrShort>.reload(verbose=false, measureEnableTime=true)
+
+       reload plugin <pkgNameOrShort>.
+
+       example: `window.pluginHelper.mo2.reload()` or `window.pluginHelper['poi-plugin-mo2'].reload()`
+
+   - window.pluginHelper.<pkgNameOrShort>.getExt()
+
+       get current reducer state of a plugin
+
+   - window.pluginHelper.<pkgNameOrShort>.getConfig()
+
+       get config data of a plugin, assuming it's located under `config.plugin.<packageName>`
+
+ */
+import _ from 'lodash'
+import { observer } from 'redux-observers'
+
+import { extensionSelectorFactory } from '../utils/selectors'
+
+const pluginHelper = {}
+
+const reloadPlugin = pkgNameOrShort => async (verbose=false, measureEnableTime=true) => {
+  const {getStore} = window
+  const {plugins} = getStore()
+  const pluginInd = plugins.findIndex(p =>
+    p.packageName === pkgNameOrShort ||
+    p.packageName === `poi-plugin-${pkgNameOrShort}`
+  )
+
+  if (pluginInd === -1) {
+    console.error(`plugin "${pkgNameOrShort}" not found`)
+    return
+  }
+  const plugin = plugins[pluginInd]
+
+  // delaying PM loading to break circular dep
+  const pluginManager = require('./plugin-manager')
+
+  /* eslint-disable no-console */
+  await pluginManager.disablePlugin(plugin)
+  if (verbose)
+    console.log(`plugin "${plugin.id}" disabled, re-enabling...`)
+
+  if (measureEnableTime)
+    console.time(`Enable ${plugin.packageName}`)
+  await pluginManager.enablePlugin(plugin)
+  if (measureEnableTime)
+    console.timeEnd(`Enable ${plugin.packageName}`)
+  if (verbose)
+    console.log(`plugin "${plugin.id}" enabled.`)
+  /* esline-enable no-console */
+}
+
+const mkTools = plugin => {
+  const {getStore, config} = window
+  const {packageName} = plugin
+
+  const getExt = () =>
+    extensionSelectorFactory(packageName)(getStore())
+
+  const getConfig = () =>
+    config.get(['plugin', packageName])
+
+  return {
+    reload: reloadPlugin(packageName),
+    getExt,
+    getConfig,
+  }
+}
+
+pluginHelper.$populate = () => {
+  // remove all plugin tools
+  _.keys(pluginHelper).map(k => {
+    if (!(/^\$.*$/.exec(k)))
+      delete pluginHelper[k]
+  })
+
+  const {getStore} = window
+  const plugins = getStore('plugins') || []
+  plugins.map(plugin => {
+    const {packageName} = plugin
+    const reResult = /^poi-plugin-(.+)$/.exec(packageName)
+    if (!reResult)
+      return
+    const [_ignored, shortNameRaw] = reResult
+    const shortName = _.camelCase(shortNameRaw)
+
+    const tools = mkTools(plugin)
+    pluginHelper[packageName] = tools
+    pluginHelper[shortName] = tools
+  })
+}
+
+pluginHelper.$reload = (pkgNameOrShort, verbose, measureEnableTime) =>
+  reloadPlugin(pkgNameOrShort)(verbose, measureEnableTime)
+
+const pluginHelperObserver = observer(
+  state =>
+    // digest plugin info by Array of packageName
+    _.map(_.get(state, ['plugins']), p => p.packageName),
+  (_dispatch, current, previous) => {
+    // setup window.pluginHelper upon initial call
+    if (typeof previous === 'undefined') {
+      window.pluginHelper = pluginHelper
+    } else {
+      // re-populate when plugin list is changed
+      if (!_.isEqual(current, previous)) {
+        pluginHelper.$populate()
+      }
+    }
+  },
+  {skipInitialCall: false}
+)
+
+export {
+  pluginHelper,
+  pluginHelperObserver,
+}

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -463,25 +463,6 @@ const pluginManager = new PluginManager(
   join(ROOT, 'assets', 'data', 'mirror.json')
 )
 
-window.reloadPlugin = async (pkgName, verbose=false) => {
-  const { plugins } = getStore()
-  const plugin = plugins.find(
-    pkg => [pkgName, `poi-plugin-${pkgName}`].includes(pkg.packageName)
-  )
-  if (!plugin) {
-    console.error(`plugin "${pkgName}" not found`)
-    return
-  }
-  await pluginManager.disablePlugin(plugin)
-  if (verbose)
-    // eslint-disable-next-line no-console
-    console.log(`plugin "${plugin.id}" disabled, re-enabling...`)
-  await pluginManager.enablePlugin(plugin)
-  if (verbose)
-    // eslint-disable-next-line no-console
-    console.log(`plugin "${plugin.id}" enabled.`)
-}
-
 window.gracefulResetPlugin = () => pluginManager.gracefulRepair(false)
 
 remote.getCurrentWebContents().once('dom-ready', () => pluginManager.initialize())


### PR DESCRIPTION
provide convenience for debugging from devtools:

(excerpted from `views/services/plugin-helper.es`)

- `window.pluginHelper.$reload(pkgNameOrShort, verbose=false, measureEnableTime=true)`
       reload a plugin. (this is the old `window.reloadPlugin` extended with the ability to measure enable time)

    - `pkgNameOrShort`: full package name or the string after prefix 'poi-plugin-'
    - `verbose`: bool, verbosity control
    - `measureEnableTime`: bool, whether time duration of enabling a plugin should be printed
- `window.pluginHelper.$populate()`
       most of the time you don't have to call this function, as it's called automatically by observer whenever the list of plugin changes.
       clear and reload all `window.pluginHelper.<pkgNameOrShort>` (see below)
- `window.pluginHelper.<pkgNameOrShort>.reload(verbose=false, measureEnableTime=true)`
       reload plugin <pkgNameOrShort>.
       example: `window.pluginHelper.mo2.reload()` or `window.pluginHelper['poi-plugin-mo2'].reload()`
- `window.pluginHelper.<pkgNameOrShort>.getExt()`
       get current reducer state of a plugin

- `window.pluginHelper.<pkgNameOrShort>.getConfig()`
       get config data of a plugin, assuming it's located under `config.plugin.<packageName>`

other changes:

- Added `'varsIgnorePattern': '^_[a-zA-Z].*'` in eslintrc. This change makes it possible to declare some variables that are intentionally unused by prefixing variable name with a `_` while still checks whether `_` (usually bound to `lodash`) or `__` (usually bound to i18n-related functions) are used.
- `window.reloadPlugin` is removed in favor of `window.pluginHelper.$reload`