### PR TITLE
Block document.write after page is loaded to prevent page from being cleared

### DIFF
--- a/assets/js/webview-preload.js
+++ b/assets/js/webview-preload.js
@@ -146,13 +146,15 @@ const handleDOMContentLoaded = () => {
 
 document.addEventListener("DOMContentLoaded", handleDOMContentLoaded)
 
-const _documentWrite = document.write
 
-document.write = function() {
-  if (document.readyState === 'interactive' || document.readyState === 'complete') {
-    console.warn(`Block document.write since document is at state "${document.readyState}". Blocked call:`, arguments)
-  } else {
-    _documentWrite.apply(this, arguments)
+if (window.location.toString().includes("http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/")) {
+  const _documentWrite = document.write
+  document.write = function() {
+    if (document.readyState === 'interactive' || document.readyState === 'complete') {
+      console.warn(`Block document.write since document is at state "${document.readyState}". Blocked call:`, arguments)
+    } else {
+      _documentWrite.apply(this, arguments)
+    }
   }
 }
 

--- a/assets/js/webview-preload.js
+++ b/assets/js/webview-preload.js
@@ -146,6 +146,16 @@ const handleDOMContentLoaded = () => {
 
 document.addEventListener("DOMContentLoaded", handleDOMContentLoaded)
 
+const _documentWrite = document.write
+
+document.write = function() {
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+    console.warn(`Block document.write since document is at state "${document.readyState}". Blocked call:`, arguments)
+  } else {
+    _documentWrite.apply(this, arguments)
+  }
+}
+
 // A workaround for drop-and-drag navigation
 remote.require('./lib/utils').stopFileNavigate(remote.getCurrentWebContents().id)
 


### PR DESCRIPTION
Some DMM ads scripts will call `document.write` after the game page is loaded which clear the entire page and cause "black screen".

It is to prevent `document.write` from running if the page is loaded.