### PR TITLE
Fix ship-tooltips PR

### DIFF
--- a/i18n/main/en-US.json
+++ b/i18n/main/en-US.json
@@ -77,5 +77,10 @@
   "<1>{{0}}</1>": "<1>{{0}}</1>",
   "OASW": "OASW",
   "AACI": "AACI",
-  "Fast+": "Fast+"
+  "Fast+": "Fast+",
+  "Lv": "Lv. {{level}}",
+  "RemodelLv": "Remodel: Lv. {{remodelLevel}}",
+  "RemodelReady": "Remodel: Ready",
+  "TotalExp": "Total: {{exp}}",
+  "NextExp": "Next: {{nextExp}}"
 }

--- a/views/components/main/parts/minishipitem.es
+++ b/views/components/main/parts/minishipitem.es
@@ -27,175 +27,6 @@ import {
   landbaseEquipDataSelectorFactory,
 } from 'views/utils/selectors'
 
-// From plugin-exp-calculator/constants.es
-const levelToExp = {
-  1: 0,
-  2: 100,
-  3: 300,
-  4: 600,
-  5: 1000,
-  6: 1500,
-  7: 2100,
-  8: 2800,
-  9: 3600,
-  10: 4500,
-  11: 5500,
-  12: 6600,
-  13: 7800,
-  14: 9100,
-  15: 10500,
-  16: 12000,
-  17: 13600,
-  18: 15300,
-  19: 17100,
-  20: 19000,
-  21: 21000,
-  22: 23100,
-  23: 25300,
-  24: 27600,
-  25: 30000,
-  26: 32500,
-  27: 35100,
-  28: 37800,
-  29: 40600,
-  30: 43500,
-  31: 46500,
-  32: 49600,
-  33: 52800,
-  34: 56100,
-  35: 59500,
-  36: 63000,
-  37: 66600,
-  38: 70300,
-  39: 74100,
-  40: 78000,
-  41: 82000,
-  42: 86100,
-  43: 90300,
-  44: 94600,
-  45: 99000,
-  46: 103500,
-  47: 108100,
-  48: 112800,
-  49: 117600,
-  50: 122500,
-  51: 127500,
-  52: 132700,
-  53: 138100,
-  54: 143700,
-  55: 149500,
-  56: 155500,
-  57: 161700,
-  58: 168100,
-  59: 174700,
-  60: 181500,
-  61: 188500,
-  62: 195800,
-  63: 203400,
-  64: 211300,
-  65: 219500,
-  66: 228000,
-  67: 236800,
-  68: 245900,
-  69: 255300,
-  70: 265000,
-  71: 275000,
-  72: 285400,
-  73: 296200,
-  74: 307400,
-  75: 319000,
-  76: 331000,
-  77: 343400,
-  78: 356200,
-  79: 369400,
-  80: 383000,
-  81: 397000,
-  82: 411500,
-  83: 426500,
-  84: 442000,
-  85: 458000,
-  86: 474500,
-  87: 491500,
-  88: 509000,
-  89: 527000,
-  90: 545500,
-  91: 564500,
-  92: 584500,
-  93: 606500,
-  94: 631500,
-  95: 661500,
-  96: 701500,
-  97: 761500,
-  98: 851500,
-  99: 1000000,
-  100: 1000000,
-  101: 1010000,
-  102: 1011000,
-  103: 1013000,
-  104: 1016000,
-  105: 1020000,
-  106: 1025000,
-  107: 1031000,
-  108: 1038000,
-  109: 1046000,
-  110: 1055000,
-  111: 1065000,
-  112: 1077000,
-  113: 1091000,
-  114: 1107000,
-  115: 1125000,
-  116: 1145000,
-  117: 1168000,
-  118: 1194000,
-  119: 1223000,
-  120: 1255000,
-  121: 1290000,
-  122: 1329000,
-  123: 1372000,
-  124: 1419000,
-  125: 1470000,
-  126: 1525000,
-  127: 1584000,
-  128: 1647000,
-  129: 1714000,
-  130: 1785000,
-  131: 1860000,
-  132: 1940000,
-  133: 2025000,
-  134: 2115000,
-  135: 2210000,
-  136: 2310000,
-  137: 2415000,
-  138: 2525000,
-  139: 2640000,
-  140: 2760000,
-  141: 2887000,
-  142: 3021000,
-  143: 3162000,
-  144: 3310000,
-  145: 3465000,
-  146: 3628000,
-  147: 3799000,
-  148: 3978000,
-  149: 4165000,
-  150: 4360000,
-  151: 4564000,
-  152: 4777000,
-  153: 4999000,
-  154: 5230000,
-  155: 5470000,
-  156: 5720000,
-  157: 5780000,
-  158: 5860000,
-  159: 5970000,
-  160: 6120000,
-  161: 6320000,
-  162: 6580000,
-  163: 6910000,
-  164: 7320000,
-  165: 7820000,
-}
-
 const slotitemsDataSelectorFactory = memoize((shipId) =>
   createSelector([
     shipDataSelectorFactory(shipId),
@@ -309,17 +140,16 @@ export class MiniShipRow extends Component {
       return <div></div>
     const labelStatusStyle = getStatusStyle(labelStatus)
     const hpPercentage = ship.api_nowhp / ship.api_maxhp * 100
+    const level = ship.api_lv
+    const remodelLevel = $ship.api_afterlv
+    const exp = (ship.api_exp || [])[0]
+    const nextExp = (ship.api_exp || [])[1]
+    const remodelString = level < remodelLevel ? `Remodel: Lv. ${remodelLevel}` : remodelLevel ? `Remodel: ready` : null
     const shipInfoClass = classNames("ship-info", {
       "ship-avatar-padding": enableAvatar,
       "ship-info-hidden": hideShipName,
       "ship-info-show": !hideShipName,
     })
-    const level = ship.api_lv
-    const nextLevel = $ship.api_afterlv
-    const exp = (ship.api_exp || [])[0]
-    const nextExp = (ship.api_exp || [])[1]
-    const maxExpString = level < 99 ? `99: ${(levelToExp[99] - exp) || '??'}` : level < 165 ? `165: ${(levelToExp[165] - exp) || '??'}` : null
-    const remodelExpString = level < nextLevel ? `Remodel: ${nextLevel}, ${(levelToExp[nextLevel] - exp) || '??'}` : nextLevel ? `Remodel: ${nextLevel}` : null
     return (
       <div className="ship-tile">
         <OverlayTrigger
@@ -346,14 +176,12 @@ export class MiniShipRow extends Component {
                       <div>{$ship.api_name ? t(`resources:${$ship.api_name}`) : '??'}</div>
                       {exp > 0 ? <div>Total: {exp}</div> : null}
                       {nextExp > 0 ? <div>Next: {nextExp}</div> : null}
-                      {remodelExpString ? <div>{remodelExpString}</div> : null}
-                      {maxExpString ? <div>{maxExpString}</div> : null}
+                      {remodelString ? <div>{remodelString}</div> : null}
                     </div>
                   ) : <div>
                     {exp > 0 ? <div>Total: {exp}</div> : null}
                     {nextExp > 0 ? <div>Next: {nextExp}</div> : null}
-                    {remodelExpString ? <div>{remodelExpString}</div> : null}
-                    {maxExpString ? <div>{maxExpString}</div> : null}
+                    {remodelString ? <div>{remodelString}</div> : null}
                   </div>
                 }
               </Tooltip>

--- a/views/components/main/parts/minishipitem.es
+++ b/views/components/main/parts/minishipitem.es
@@ -144,7 +144,7 @@ export class MiniShipRow extends Component {
     const remodelLevel = $ship.api_afterlv
     const exp = (ship.api_exp || [])[0]
     const nextExp = (ship.api_exp || [])[1]
-    const remodelString = level < remodelLevel ? `Remodel: Lv. ${remodelLevel}` : remodelLevel ? `Remodel: ready` : null
+    const remodelString = level < remodelLevel ? t('main:RemodelLv', { remodelLevel }) : remodelLevel ? t('main:RemodelReady') : null
     const shipInfoClass = classNames("ship-info", {
       "ship-avatar-padding": enableAvatar,
       "ship-info-hidden": hideShipName,
@@ -165,7 +165,7 @@ export class MiniShipRow extends Component {
           <div className="ship-item">
             { enableAvatar && (
               <Avatar mstId={$ship.api_id} isDamaged={hpPercentage <= 50} height={33}>
-                {compact ? <div className='ship-lv-avatar'>Lv. {level || '??'}</div> : null}
+                {compact && <div className='ship-lv-avatar'>{level && t('main:Lv', { level })}</div>}
               </Avatar>
             ) }
             <OverlayTrigger placement='top' overlay={
@@ -173,15 +173,20 @@ export class MiniShipRow extends Component {
                 {
                   hideShipName ? (
                     <div className="ship-tooltip-info">
-                      <div>{$ship.api_name ? t(`resources:${$ship.api_name}`) : '??'}</div>
-                      {exp > 0 ? <div>Total: {exp}</div> : null}
-                      {nextExp > 0 ? <div>Next: {nextExp}</div> : null}
-                      {remodelString ? <div>{remodelString}</div> : null}
+                      <div>
+                        {$ship.api_name ? t(`resources:${$ship.api_name}`) : '??'}
+                      </div>
+                      <div>
+                        {level && t('main:Lv', { level })}
+                      </div>
+                      {exp > 0 && <div>{t('main:TotalExp', { exp })}</div>}
+                      {nextExp > 0 && <div>{t('main:NextExp', { nextExp })}</div>}
+                      {remodelString && <div>{remodelString}</div>}
                     </div>
                   ) : <div>
-                    {exp > 0 ? <div>Total: {exp}</div> : null}
-                    {nextExp > 0 ? <div>Next: {nextExp}</div> : null}
-                    {remodelString ? <div>{remodelString}</div> : null}
+                    {exp > 0 && <div>{t('main:TotalExp', { exp })}</div>}
+                    {nextExp > 0 && <div>{t('main:NextExp', { nextExp })}</div>}
+                    {remodelString && <div>{remodelString}</div>}
                   </div>
                 }
               </Tooltip>
@@ -194,7 +199,7 @@ export class MiniShipRow extends Component {
                         {$ship.api_name ? t(`resources:${$ship.api_name}`) : '??'}
                       </span>
                       <span className="ship-lv-text top-space" style={labelStatusStyle}>
-                        Lv. {level || '??'}
+                        {level && t('main:Lv', { level })}
                       </span>
                     </>
                   )


### PR DESCRIPTION
New version:
![1](https://user-images.githubusercontent.com/13043588/40765411-54f37e76-64e7-11e8-9e38-1f973985dfa3.png)
![2](https://user-images.githubusercontent.com/13043588/40765412-5553931a-64e7-11e8-8a04-d637546d2ff2.png)
![3](https://user-images.githubusercontent.com/13043588/40765413-557f0b6c-64e7-11e8-8445-0bff2303f0e2.png)
`Remodel: ready` for reversible remodels as well (like Shoukaku).