### PR TITLE
Fix quest translations in overview

### DIFF
--- a/views/components/main/parts/task-panel.es
+++ b/views/components/main/parts/task-panel.es
@@ -185,10 +185,10 @@ const TaskRow = translate(['resources'])(connect(
     record: get(state, ['info', 'quests', 'records', quest.api_no]),
     translation: get(extensionSelectorFactory('poi-plugin-quest-info')(state), ['quests', quest.api_no, 'condition']),
     wikiId: get(extensionSelectorFactory('poi-plugin-quest-info')(state), ['quests', quest.api_no, 'wiki_id']),
-    title: get(extensionSelectorFactory('poi-plugin-quest-info')(state), ['quests', quest.api_no, 'title']),
   })
-)(function ({idx, quest, record, translation, wikiId, title, colwidth, t}) {
-  const questName = title ? title : quest && quest.api_title ? t(`resources:${ escapeI18nKey(quest.api_title) }`) : '???'
+)(function ({idx, quest, record, translation, wikiId, colwidth, t}) {
+  const wikiIdPrefix = wikiId ? `${wikiId} - ` : ''
+  const questName = quest && quest.api_title ? t(`resources:${quest.api_title}`, { context: quest.api_no && quest.api_no.toString() }) : '???'
   const questContent = translation ? translation : quest ? quest.api_detail.replace(/<br\s*\/?>/gi, '') : '...'
   const [count, required] = sumSubgoals(record)
   const progressBsStyle = record ?
@@ -204,8 +204,8 @@ const TaskRow = translate(['resources'])(connect(
     <TaskRowBase
       idx={idx}
       bulletColor={quest ? getCategory(quest.api_category) : '#fff'}
-      leftLabel={questName}
-      leftOverlay={<div><strong>{wikiId ? `${wikiId} - ` : ''}{questName}</strong><br />{questContent}</div>}
+      leftLabel={`${wikiIdPrefix}${questName}`}
+      leftOverlay={<div><strong>{wikiIdPrefix}{questName}</strong><br />{questContent}</div>}
       rightLabel={progressLabel}
       rightBsStyle={progressBsStyle}
       rightOverlay={progressOverlay}


### PR DESCRIPTION
Instead of importing titles from quest plugin, prefix with wiki ids (same as expeditions) from it and use translator plugin for titles with api id contexts.
![u](https://user-images.githubusercontent.com/13043588/44630340-92548000-a996-11e8-96e4-487756079bcc.png)
without quest plugin will be no wiki id prefixes and no requirement translations, quest titles should be provided via translator plugin.