### PR TITLE
Remove npm mirror selection in gulp

### DIFF
--- a/build/utils.es
+++ b/build/utils.es
@@ -6,28 +6,7 @@ import n7z from 'node-7z'
 
 const { ROOT } = global
 export const NPM_EXEC_PATH = path.join(ROOT, 'node_modules', 'npm', 'bin', 'npm-cli.js')
-export const MIRROR_JSON_PATH = path.join(ROOT, 'assets', 'data', 'mirror.json')
 export const PLUGIN_JSON_PATH = path.join(ROOT, 'assets', 'data', 'plugin.json')
-
-const config = (() => {
-  // global.* variables are assigned to adapt for requiring 'config'
-
-  return require('../lib/config')
-})()
-
-const NPM_SERVER = (() => {
-  const mirrors = fs.readJsonSync(MIRROR_JSON_PATH)
-  // Don't want to mess with detecting system language here without window.navigator
-  const language = config.get('poi.misc.language', 'zh-CN')
-  const primaryServer = language === 'zh-CN' ? 'taobao' : 'npm'
-  let server = config.get("packageManager.mirrorName", primaryServer)
-  if (process.env.TRAVIS || process.env.APPVEYOR) {
-    server = 'npm'
-  }
-  return mirrors[server].server
-})()
-
-log(`Using npm mirror ${NPM_SERVER}`)
 
 export const compress7z = async (files, archive, options) => {
   try {
@@ -45,11 +24,11 @@ export const runScript = (scriptPath, args, options) => new Promise ((resolve) =
 })
 
 
-export const npmInstall = async (tgtDir, args=[], ci=true) => {
+export const npmInstall = async (tgtDir, args = [], ci = true) => {
   // Can't use require('npm') module b/c we kept npm2 in node_modules for plugins
   log(`Installing npm for ${tgtDir}`)
   await fs.ensureDir(tgtDir)
-  await runScript(NPM_EXEC_PATH, [ci ? 'ci' : 'i', '--registry', NPM_SERVER].concat(args),{
+  await runScript(NPM_EXEC_PATH, [ci ? 'ci' : 'i'].concat(process.argv.slice(3)).concat(args), {
     cwd: tgtDir,
   })
   log(`Finished installing npm for ${tgtDir}`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,7 @@
 require('@babel/register')(require('./babel.config'))
 const gulp = require('gulp')
-const path = require('path')
 
 global.ROOT = __dirname
-const SYS_APPDATA_PATH = process.env.APPDATA || (
-  process.platform == 'darwin'
-    ? path.join(process.env.HOME, 'Library/Application Support')
-    : '/var/local')
-global.APPDATA_PATH = path.join(SYS_APPDATA_PATH, 'poi')
-global.EXROOT = global.APPDATA_PATH
 
 const { log } = require('./lib/utils')
 const {
@@ -40,10 +33,13 @@ gulp.task('pack_win_release', gulp.series('getVersion', () => packWinRelease(poi
 gulp.task('clean', () => cleanFiles())
 
 gulp.task('default', (done) => {
-  const _gulp = 'gulp'
-  log("Usage:")
-  log(`  ${_gulp} deploy          - Make this repo ready to use`)
-  log(`  ${_gulp} build           - Build release complete packages under ./dist/`)
-  log(`  ${_gulp} build_plugins   - Pack up latest plugin tarballs under ./dist/`)
+  log`
+  Usage:
+  gulp deploy          - Make this repo ready to use
+  gulp build           - Build release complete packages under ./dist/
+  gulp build_plugins   - Pack up latest plugin tarballs under ./dist/
+
+  extra arguments will be passed to npm if it is used
+  `
   done()
 })


### PR DESCRIPTION
gulp tasks not working on Linux without `sudo` since `/var/local` is only writable by root. Mimicking [`app.getPath('appData')`](https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname) so that the right path (`$XDG_CONFIG_HOME/poi` or `~/.config/poi`) is used on Linux as well.