### PR TITLE
Allows for reloading a broken plugin in GUI panel

### DIFF
--- a/i18n/setting/en-US.json
+++ b/i18n/setting/en-US.json
@@ -133,6 +133,7 @@
   "Disable": "Disable",
   "Enable": "Enable",
   "Remove": "Remove",
+  "Reload": "Reload",
   "Installing": "Installing",
   "PluginUpdateMsg": "have newer version. Please update your plugins.",
   "Plugin update": "Plugin update",

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -94,6 +94,7 @@
   "Updating": "更新中",
   "Latest": "既に最新バージョンです",
   "Remove": "削除",
+  "Reload": "リロード",
   "Removing": "削除中",
   "Removed": "削除済",
   "Manually install": "手動インストール",

--- a/i18n/setting/ko-KR.json
+++ b/i18n/setting/ko-KR.json
@@ -86,6 +86,7 @@
   "Updating": "업데이트중",
   "Latest": "최신",
   "Remove": "삭제",
+  "Reload": "다시로드",
   "Removing": "삭제중",
   "Removed": "삭제됨",
   "Manually install": "수동 설치",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -94,6 +94,7 @@
   "Updating": "更新中",
   "Latest": "无更新",
   "Remove": "删除",
+  "Reload": "刷新",
   "Removing": "删除中",
   "Removed": "已删除",
   "Manually install": "手动安装",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -94,6 +94,7 @@
   "Updating": "更新中",
   "Latest": "無更新",
   "Remove": "刪除",
+  "Reload": "刷新",
   "Removing": "刪除中",
   "Removed": "已刪除",
   "Manually install": "手動安裝",

--- a/views/components/settings/plugin/index.es
+++ b/views/components/settings/plugin/index.es
@@ -76,6 +76,9 @@ export class PluginConfig extends Component {
       break
     }
   }
+  handleReload = async (index) => {
+    await PluginManager.reloadPlugin(this.props.plugins[index])
+  }
   handleInstall = async (name, e) => {
     if (get(e, 'target.disabled')) {
       return
@@ -543,6 +546,7 @@ export class PluginConfig extends Component {
                   handleUpdate={partial(this.handleUpdate, index)}
                   handleEnable={partial(this.handleEnable, index)}
                   handleRemove={partial(this.handleRemove, index)}
+                  handleReload={partial(this.handleReload, index)}
                 />
               )
             }, this)

--- a/views/components/settings/plugin/installed-plugin.es
+++ b/views/components/settings/plugin/installed-plugin.es
@@ -17,6 +17,7 @@ export class InstalledPlugin extends PureComponent {
     handleUpdate: PropTypes.func,
     handleEnable: PropTypes.func,
     handleRemove: PropTypes.func,
+    handleReload: PropTypes.func,
   }
   state = {
     settingOpen: false,
@@ -49,8 +50,8 @@ export class InstalledPlugin extends PureComponent {
       enableBtnFAname = 'ban'
       break
     case PluginManager.BROKEN:
-      enableBtnText = <Trans>setting:Error</Trans>
-      enableBtnFAname = 'close'
+      enableBtnText = <Trans>setting:Reload</Trans>
+      enableBtnFAname = 'refresh'
       break
     default:
       enableBtnText = ''
@@ -137,7 +138,8 @@ export class InstalledPlugin extends PureComponent {
                     }>
                       <Button bsStyle="info"
                         disabled={PluginManager.getStatusOfPlugin(plugin) == PluginManager.NEEDUPDATE}
-                        onClick={this.props.handleEnable}
+                        onClick={PluginManager.getStatusOfPlugin(plugin) != PluginManager.BROKEN ?
+                          this.props.handleEnable : this.props.handleReload}
                         className={btnClass}>
                         <FontAwesome name={enableBtnFAname}/>
                       </Button>

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -11,10 +11,10 @@ import i18next from 'views/env-parts/i18next'
 const {config, toast, proxy, ROOT, PLUGIN_PATH, dispatch, getStore} = window
 
 const fetchHeader = new Headers()
-fetchHeader.set("Cache-Control", "max-age=0")
+fetchHeader.set('Cache-Control', 'max-age=0')
 const defaultFetchOption = {
-  method: "GET",
-  cache: "default",
+  method: 'GET',
+  cache: 'default',
   headers: fetchHeader,
 }
 
@@ -53,7 +53,7 @@ class PluginManager extends EventEmitter {
     }
     this.npmConfig = {
       prefix: this.pluginRoot,
-      registry: "https://registry.npmjs.org",
+      registry: 'https://registry.npmjs.org',
       progress: false,
     }
     this.VALID = 0
@@ -101,9 +101,9 @@ class PluginManager extends EventEmitter {
   loadConfig() {
     const mirrorConf = config.get('packageManager.mirrorName')
     const mirrorName = Object.keys(this.mirrors).includes(mirrorConf) ?
-      mirrorConf : ((navigator.language === 'zh-CN') ?  "taobao" : "npm")
-    const proxyConf = config.get("packageManager.proxy", false)
-    const betaCheck = config.get("packageManager.enableBetaPluginCheck", false)
+      mirrorConf : ((navigator.language === 'zh-CN') ?  'taobao' : 'npm')
+    const proxyConf = config.get('packageManager.proxy', false)
+    const betaCheck = config.get('packageManager.enableBetaPluginCheck', false)
     this.selectConfig(mirrorName, proxyConf, betaCheck, false)
 
     return this.mirrors
@@ -111,15 +111,15 @@ class PluginManager extends EventEmitter {
   selectConfig(name, enable, check) {
     if (name) {
       this.config.mirror = this.mirrors[name]
-      config.set("packageManager.mirrorName", name)
+      config.set('packageManager.mirrorName', name)
     }
     if (enable != null) {
       this.config.proxy = enable
-      config.set("packageManager.proxy", enable)
+      config.set('packageManager.proxy', enable)
     }
     if (check != null) {
       this.config.betaCheck = check
-      config.set("packageManager.enableBetaPluginCheck", check)
+      config.set('packageManager.enableBetaPluginCheck', check)
     }
     this.npmConfig.registry = this.config.mirror.server
     if (this.config.proxy) {
@@ -347,7 +347,7 @@ class PluginManager extends EventEmitter {
     const packageName = installingByPluginName ? packageSource :
       await findInstalledTarball(join(this.pluginRoot, 'node_modules'), packageSource)
 
-      // 4) Unload plugin if it's running
+    // 4) Unload plugin if it's running
     const nowPlugin = getStore('plugins').find((plugin) => plugin.packageName === packageName)
     if (nowPlugin) {
       try {

--- a/views/services/plugin-manager.es
+++ b/views/services/plugin-manager.es
@@ -11,10 +11,10 @@ import i18next from 'views/env-parts/i18next'
 const {config, toast, proxy, ROOT, PLUGIN_PATH, dispatch, getStore} = window
 
 const fetchHeader = new Headers()
-fetchHeader.set('Cache-Control', 'max-age=0')
+fetchHeader.set("Cache-Control", "max-age=0")
 const defaultFetchOption = {
-  method: 'GET',
-  cache: 'default',
+  method: "GET",
+  cache: "default",
   headers: fetchHeader,
 }
 
@@ -53,7 +53,7 @@ class PluginManager extends EventEmitter {
     }
     this.npmConfig = {
       prefix: this.pluginRoot,
-      registry: 'https://registry.npmjs.org',
+      registry: "https://registry.npmjs.org",
       progress: false,
     }
     this.VALID = 0
@@ -101,9 +101,9 @@ class PluginManager extends EventEmitter {
   loadConfig() {
     const mirrorConf = config.get('packageManager.mirrorName')
     const mirrorName = Object.keys(this.mirrors).includes(mirrorConf) ?
-      mirrorConf : ((navigator.language === 'zh-CN') ?  'taobao' : 'npm')
-    const proxyConf = config.get('packageManager.proxy', false)
-    const betaCheck = config.get('packageManager.enableBetaPluginCheck', false)
+      mirrorConf : ((navigator.language === 'zh-CN') ?  "taobao" : "npm")
+    const proxyConf = config.get("packageManager.proxy", false)
+    const betaCheck = config.get("packageManager.enableBetaPluginCheck", false)
     this.selectConfig(mirrorName, proxyConf, betaCheck, false)
 
     return this.mirrors
@@ -111,15 +111,15 @@ class PluginManager extends EventEmitter {
   selectConfig(name, enable, check) {
     if (name) {
       this.config.mirror = this.mirrors[name]
-      config.set('packageManager.mirrorName', name)
+      config.set("packageManager.mirrorName", name)
     }
     if (enable != null) {
       this.config.proxy = enable
-      config.set('packageManager.proxy', enable)
+      config.set("packageManager.proxy", enable)
     }
     if (check != null) {
       this.config.betaCheck = check
-      config.set('packageManager.enableBetaPluginCheck', check)
+      config.set("packageManager.enableBetaPluginCheck", check)
     }
     this.npmConfig.registry = this.config.mirror.server
     if (this.config.proxy) {
@@ -347,7 +347,7 @@ class PluginManager extends EventEmitter {
     const packageName = installingByPluginName ? packageSource :
       await findInstalledTarball(join(this.pluginRoot, 'node_modules'), packageSource)
 
-    // 4) Unload plugin if it's running
+      // 4) Unload plugin if it's running
     const nowPlugin = getStore('plugins').find((plugin) => plugin.packageName === packageName)
     if (nowPlugin) {
       try {
@@ -450,6 +450,16 @@ class PluginManager extends EventEmitter {
       value: plugin,
     })
   }
+  
+  async reloadPlugin(plugin) {
+    try {
+      await this.disablePlugin(plugin)
+      plugin.isBroken = false
+      await this.enablePlugin(plugin)
+    } catch (error) {
+      console.error(error.stack)
+    }
+  }
 }
 
 const pluginManager = new PluginManager(
@@ -467,15 +477,7 @@ window.reloadPlugin = async (pkgName, verbose=false) => {
     console.error(`plugin "${pkgName}" not found`)
     return
   }
-  await pluginManager.disablePlugin(plugin)
-  if (verbose)
-    // eslint-disable-next-line no-console
-    console.log(`plugin "${plugin.id}" disabled, re-enabling...`)
-  plugin.isBroken = false
-  await pluginManager.enablePlugin(plugin)
-  if (verbose)
-    // eslint-disable-next-line no-console
-    console.log(`plugin "${plugin.id}" enabled.`)
+  await pluginManager.reloadPlugin(plugin)
 }
 
 window.gracefulResetPlugin = () => pluginManager.gracefulRepair(false)


### PR DESCRIPTION
Previously the only way to reload a broken plugin was by using `reloadPlugin` command in console in Developer Tools window, this PR replaces a non-functional button indicating that the plugin is broken and allows for dynamic reloading of a plugin from GUI level. 