### PR TITLE
Update to ship indicators

### DIFF
--- a/views/utils/aaci.es
+++ b/views/utils/aaci.es
@@ -124,6 +124,7 @@ const isMusashiK2 = shipIdIs(546)
 const isHamakazeBK = shipIdIs(558)
 const isIsokazeBK = shipIdIs(557)
 const isTenryuuK2 = shipIdIs(477)
+const isGotlandKai = shipIdIs(579)
 
 // "hasAtLeast(pred)(n)(xs)" is the same as:
 // xs.filter(pred).length >= n
@@ -516,6 +517,18 @@ declareAACI({
       hasSome(is20Tube7InchUpRocketLaunchers),
       hasSome(is16InchMkITriplePlusFCR),
     ),
+  ),
+})
+
+declareAACI({
+  name: ['Gotland Kai'],
+  id: 33,
+  fixed: 4,
+  modifier: 1.35,
+  shipValid: isGotlandKai,
+  equipsValid: validAll(
+    hasSome(isHighAngleMount),
+    hasSome(isAAGun),
   ),
 })
 

--- a/views/utils/aaci.es
+++ b/views/utils/aaci.es
@@ -103,7 +103,7 @@ const isAkizukiClass = ship => ship.api_ctype === 54
 const isRoyalNavyShips = ship => [67, 78, 82, 88].includes(ship.api_ctype)
 
 // 6 = 金剛型
-const isKongouClassK2 = ship => ship.api_ctype === 6 && ship.aftership_id === '0'
+const isKongouClassK2 = ship => ship.api_ctype === 6 && ship.api_aftershipid === '0'
 
 const shipIdIs = n => ship => ship.api_ship_id === n
 

--- a/views/utils/aaci.es
+++ b/views/utils/aaci.es
@@ -99,7 +99,8 @@ const isAkizukiClass = ship => ship.api_ctype === 54
 // 67 = Queen Elizabeth class
 // 78 = Ark Royal class
 // 82 = J class
-const isHMSRoyalNavyShips = ship => [67, 78, 82].includes(ship.api_ctype)
+// 88 = Nelson class
+const isRoyalNavyShips = ship => [67, 78, 82, 88].includes(ship.api_ctype)
 
 // 6 = 金剛型
 const isKongouClassK2 = ship => ship.api_ctype === 6 && ship.aftership_id === '0'
@@ -506,7 +507,7 @@ declareAACI({
   fixed: 4,
   modifier: 1.2,
   shipValid: validAny(
-    isHMSRoyalNavyShips,
+    isRoyalNavyShips,
     isKongouClassK2,
   ),
   equipsValid: validAll(

--- a/views/utils/aapb.es
+++ b/views/utils/aapb.es
@@ -1,40 +1,124 @@
-import { countBy } from 'lodash'
+/*
+   reference:
 
-const isAAGun = equip => equip.api_type[2] === 21
-const isHighAngleMount = equip => equip.api_type[3] === 16
-const isAAFireDirector = equip => equip.api_type[2] === 36
-const isAARadar = equip => [12, 13].includes(equip.api_type[2]) && equip.api_tyku > 0
+   - http://kancolle.wikia.com/wiki/12cm_30-tube_Rocket_Launcher_Kai_Ni (as of Oct 18, 2018)
+   - http://kancolle.wikia.com/wiki/Combat#/Aerial (as of Oct 18, 2018)
+   - https://wikiwiki.jp/kancolle/航空戦#h2_content_1_6 (as of Oct 18, 2018)
+   - https://twitter.com/kankenRJ/status/979524073934893056
+   - https://twitter.com/noratako5/status/976988915734228992
 
-// 12cm30連装噴進砲改二
-const isTubeRocketLauncherKai2 = equip => equip.api_slotitem_id === 274
+ */
 
-// 6=航空巡洋艦 7=軽空母 10=航空戦艦 11=正規空母 16=水上機母艦 18=装甲空母
-const canAAPB = ship => [6, 7, 10, 11, 16, 18].includes(ship.api_stype)
-
-// 2=伊勢型
-const isIseClass = ship => ship.api_ctype === 2
+const isAAGun = $equip => $equip.api_type[2] === 21
+const isHighAngleMount = $equip => $equip.api_type[3] === 16
+const isAAFireDirector = $equip => $equip.api_type[2] === 36
+const isAARadar = $equip => [12, 13].includes($equip.api_type[2]) && $equip.api_tyku > 0
 
 // 加重対空値
-const getEquipWeightedAA = equip => {
-  if (isAAGun(equip)) return equip.api_tyku * 6 + 4 * equip.api_level ** .5
-  if (isHighAngleMount(equip)) return equip.api_tyku * 4 + 3 * equip.api_level ** .5
-  if (isAAFireDirector(equip)) return equip.api_tyku * 4
-  if (isAARadar(equip)) return equip.api_tyku * 3
+/*
+   note that there are inconsistency conclusions
+   between wikiwiki and wikia (indicated below),
+   we'll prefer wikiwiki for it's updated more recently (as of Oct 18, 2018)
+   unless further experiment proves otherwise.
+ */
+const getEquipWeightedAA = ([equip, $equip]) => {
+  // equip AA = (E_fmod * E_AA) + (E_f* * sqrt(lvl))
+  if (isAAGun($equip)) {
+    return 6 * $equip.api_tyku + 4 * Math.sqrt(equip.api_level)
+  }
+  if (isHighAngleMount($equip)) {
+    /*
+       inconsistency:
+       - equipment's improvement modifier is always 3 in wikia,
+       - while in wikiwiki, HA with AA stat <= 7 has a factor of 2
+
+     */
+    if ($equip.api_tyku >= 8) {
+      // 素対空8以上
+      return 4 * $equip.api_tyku + 3 * Math.sqrt(equip.api_level)
+    } else {
+      // 素対空7以下
+      return 4 * $equip.api_tyku + 2 * Math.sqrt(equip.api_level)
+    }
+  }
+  if (isAAFireDirector($equip)) {
+    /*
+       inconsistency:
+       - AAFD's improvement modifier is not present in wikia
+       - it's 2 in wikiwiki
+     */
+    return 4 * $equip.api_tyku + 2 * Math.sqrt(equip.api_level)
+  }
+  if (isAARadar($equip)) {
+    return 3 * $equip.api_tyku
+  }
   return 0
 }
 
-// 艦の素対空値
-const getShipAA = (ship, equips) => ship.api_taiku[0] - equips.reduce((total, equip) => total + equip.api_tyku, 0)
+const capableShipTypes = [
+  // 航空巡洋艦
+  6,
+  // 軽空母
+  7,
+  // 航空戦艦
+  10,
+  // 正規空母
+  11,
+  // 水上機母艦
+  16,
+  // 装甲空母
+  18,
+]
 
-export const getShipAAPB = (ship, equips) => {
-  if (!canAAPB(ship)) return 0
-  if (!equips.find(e => isTubeRocketLauncherKai2(e))) return 0
+/*
+   getShipAAPB(<ShipInfo>, <EquipsInfo>): number
 
-  const rocketCount = countBy(equips, isTubeRocketLauncherKai2).true
-  const weightedAA = equips.reduce((total, equip) => total + getEquipWeightedAA(equip), 0) + getShipAA(ship, equips)
+   - return value x means a success rate of `x%`
+   - ShipInfo: Array of shape [ship, $ship]
+   - EquipsInfo: Array of `EquipInfo`,
+       where EquipInfo at least has shape: [equip, $equip, onslot]
+ */
+export const getShipAAPB = (...args) => {
+  const [[ship, $ship], equipsInfo] = args
+  if (!capableShipTypes.includes($ship.api_stype))
+    return 0
 
-  let rate = isIseClass(ship) ? 25 : 0
-  rate += (rocketCount - 1) * 15
-  rate += (ship.api_lucky[0] + weightedAA) / 2.82
-  return Math.min(rate, 100).toFixed(2)
+  let rlk2Count = 0
+  equipsInfo.forEach(([_ignored, $equip]) => {
+    // 12cm30連装噴進砲改二
+    if ($equip.api_id === 274) {
+      rlk2Count += 1
+    }
+  })
+
+  if (rlk2Count === 0)
+    return 0
+
+  const iseClassBonus = $ship.api_ctype === 2 ? 70 : 0
+
+  // 艦の素対空値
+  /*
+     note that deduction from current AA stat might result in some value higher
+     than it actually is due to the possible existence of hidden bonus,
+     of which everyone enjoys keeping track (thank you Tanaka, you're welcome).
+     but here we want to obtain ship's basic AA **excluding** all equipments' bonus,
+     for now the easiest approach is to work from $ship and ships' own modernization state.
+   */
+  const basicAA = $ship.api_tyku[0] + ship.api_kyouka[2]
+  let adjustedAA = basicAA
+  equipsInfo.forEach(e => {
+    adjustedAA += getEquipWeightedAA(e)
+  })
+
+  /*
+     wikiwiki:
+     - 加重対空値 = A × [X / A] []内は端数切捨て
+     - Aは迎撃艦の装備数で変化、何にも装備していない場合は1、アイテムを1つ以上装備している場合は2
+
+     at this point we have rlk2Count > 0, which means the ship in question
+     must have equipped something, so we can say A = 2
+   */
+  adjustedAA = 2 * Math.floor(adjustedAA / 2)
+  // as we want to show the precentage, let *100 here to obtain a better precision.
+  return (adjustedAA + ship.api_lucky[0])*100 /(322 - 40*rlk2Count - iseClassBonus)
 }

--- a/views/utils/oasw.es
+++ b/views/utils/oasw.es
@@ -34,9 +34,11 @@ const equipTaisAbove = value => equip => equipTais(equip) >= value
 const overEquips = func => (_ship, equips) => func(equips)
 
 /*
-   - reference as of Apr 10, 2018:
+   - reference as of Oct 18, 2018:
 
        http://wikiwiki.jp/kancolle/?%C2%D0%C0%F8%C0%E8%C0%A9%C7%FA%CD%EB%B9%B6%B7%E2
+
+   - Shinyou-related OASW is kinda too messy at this point to be put here.
 
    - regarding _.overSome, _overEvery:
 
@@ -70,8 +72,18 @@ export const isOASWWith = allCVEIds => _.overSome(
     )
   ),
   _.overEvery(
-    // 駆逐 軽巡 雷巡 練巡
-    ship => [2, 3, 4, 21].includes(ship.api_stype),
+    ship => [
+      // 駆逐
+      2,
+      // 軽巡
+      3,
+      // 雷巡
+      4,
+      // 練巡
+      21,
+      // 補給
+      22,
+    ].includes(ship.api_stype),
     taisenAbove(100),
     overEquips(hasSome(isSonar)),
   ),


### PR DESCRIPTION
a patch to several ship indicators:

- `OASW`: reformatted a bit, add support OASW for AO ~~as if someone actually cares~~
  (was planned to do something about Shinyou related OASW, but we still don't have sufficient results to draw a concise conclusion)
- `AACI`: now supports AACI related to Nelson & Gotland
- `AAPB`: refactor & improved formula, also removed the "100%" cap - as the formula is not accurate in some corner cases, it's useful to show values beyond 100%