### PR TITLE
(readme) Added poi windows install using chocolatey.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Homebrew Cask (macOS, maintained by @darg20127).
 brew update && brew cask install poi
 ```
 
+[Chocolatey](https://chocolatey.org/packages/poi) (Windows, maintained by @chocolatey and @drel).
+```shell
+choco install poi
+```
+
 ## Features
 
 + Proxy


### PR DESCRIPTION
Adding chocolatey install guide in the "UNOFFICIAL releases" section. https://github.com/poooi/poi/issues/1979
