### PR TITLE
Update plugin-setting-wrapper.es

### DIFF
--- a/views/components/settings/plugin/plugin-setting-wrapper.es
+++ b/views/components/settings/plugin/plugin-setting-wrapper.es
@@ -25,7 +25,18 @@ export class PluginSettingWrapper extends Component {
 
   shouldComponentUpdate = (nextProps, nextState) =>
     this.props.plugin.timestamp !== nextProps.plugin.timestamp ||
-    nextState.hasError === true
+    nextState.hasError === true ||
+    nextState.hasError !== this.state.hasError
+  
+  componentDidUpdate = (prevProps) => {
+    if (this.state.hasError && this.props.plugin.timestamp !== prevProps.plugin.timestamp) {
+      this.setState({
+        hasError: false,
+        error: null,
+        info: null,
+      })
+    }
+  }
 
   render() {
     const { hasError, error, info } = this.state


### PR DESCRIPTION
Dynamic reloading of plugins does not reflect the update in the Settings panel in case it goes from broken to fixed state - this PR solves this issue by assuming the problem has been fixed and allowing the error handlers to rethrow an error, if not. Otherwise it's forever stuck in hasError: true mode.