### PR TITLE
Merge default values to user config

### DIFF
--- a/app.js
+++ b/app.js
@@ -292,7 +292,7 @@ app.on('ready', () => {
   }
 
   // devtool
-  if (dbg.isEnabled() && config.get('poi.devtool.enable', true)) {
+  if (dbg.isEnabled() && config.get('poi.devtool.enable', false)) {
     require('./lib/devtool')
   }
 })

--- a/lib/config.es
+++ b/lib/config.es
@@ -45,7 +45,7 @@ class PoiConfig extends EventEmitter {
         warn('There might be a mssing config default, check', stringPath, value)
       }
     }
-    return get(this.configData, path, value)
+    return get(this.configData, path, this.getDefault(path, value))
   }
 
   /**
@@ -67,6 +67,9 @@ class PoiConfig extends EventEmitter {
   set = (path, value) => {
     if (get(this.configData, path) === value) {
       return
+    }
+    if (value === undefined && this.getDefault(path) !== undefined) {
+      value = this.getDefault(path)
     }
     set(this.configData, path, value)
     path = Array.isArray(path) ? path.join('.') : path

--- a/lib/config.es
+++ b/lib/config.es
@@ -26,6 +26,11 @@ class PoiConfig extends EventEmitter {
     this.defaultConfigData = defaultConfig
   }
 
+  /**
+   * get a config value at give path
+   * @param {String | String[]} path the given config location
+   * @param value value to fallback if queried config is undefined
+   */
   get = (path = '', value) => {
     if (path === '') {
       return this.configData
@@ -43,6 +48,10 @@ class PoiConfig extends EventEmitter {
     return get(this.configData, path, value)
   }
 
+  /**
+   * get default config value at give path
+   * @param {String | String[]} path the given config location
+   */
   getDefault = (path = '') => {
     if (path === '') {
       return this.defaultConfigData
@@ -50,21 +59,35 @@ class PoiConfig extends EventEmitter {
     return get(this.defaultConfigData, path)
   }
 
+  /**
+   * set a config value at give path
+   * @param {String | String[]} path the given config location
+   * @param value value to overwrite, if the path belongs to poi's default config, will reset to default value
+   */
   set = (path, value) => {
     if (get(this.configData, path) === value) {
       return
     }
     set(this.configData, path, value)
+    path = Array.isArray(path) ? path.join('.') : path
     this.emit('config.set', path, value)
     this.save()
   }
 
+  /**
+   * set a config value only when it is not set (addition only)
+   * @param {String | String[]} path the given config location
+   * @param value value to overwrite, leaving undefined will remove the config
+   */
   setDefault = (path, value) => {
     if (this.get(path) === undefined) {
       this.set(path, value)
     }
   }
 
+  /**
+   * save current config to file
+   */
   save = () => {
     try {
       fs.writeFileSync(configPath, CSON.stringify(this.configData, null, 2))
@@ -73,10 +96,14 @@ class PoiConfig extends EventEmitter {
     }
   }
 
+  /**
+   * remove a config at given path
+   * @param {String | String[]} path path to remove
+   */
   delete = path => {
     if (typeof this.get(path) !== 'undefined') {
       let p = this.configData
-      const subpath = path.split('.')
+      const subpath = Array.isArray(path) ? path : path.split('.')
       for (const sub of subpath.slice(0, subpath.length - 1)) {
         p = p[sub]
       }

--- a/lib/default-config.es
+++ b/lib/default-config.es
@@ -13,6 +13,9 @@ const defaultConfig = {
       screenshot: {
         format: 'png',
       },
+      cache: {
+        path: global.DEFAULT_CACHE_PATH,
+      },
     },
     content: {
       resizable: true,
@@ -25,6 +28,7 @@ const defaultConfig = {
       svgicon: false,
       textspacingcjk: true,
       vibrant: 0,
+      customtitlebar: process.platform === 'win32' || process.platform === 'linux',
     },
     window: {
       isMaximized: false,
@@ -39,6 +43,7 @@ const defaultConfig = {
     },
     webview: {
       useFixedResolution: true,
+      windowUseFixedResolution: true,
       windowWidth: 1200,
       width: 1200,
       ratio: {

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -3,22 +3,56 @@ global.ROOT = global.EXROOT = __dirname
 
 let config = null
 
-describe('config', function() {
-  beforeEach(function() {
+describe('config merging', () => {
+  const { mergeConfig } = require('../../lib/utils')
+
+  const defaultConfig = {
+    foo: 'bar',
+    year: 2018,
+    bits: [0, 1],
+    galaxy: {
+      answer: 42,
+    },
+  }
+
+  it('returns new object', () => {
+    assert.ok(mergeConfig(defaultConfig, {}) !== defaultConfig)
+  })
+
+  it('default config value is not the same type of that user config, use default configs value', () => {
+    assert.deepEqual(mergeConfig(defaultConfig, {}), defaultConfig)
+    assert.deepEqual(mergeConfig(defaultConfig, { galaxy: [42] }), defaultConfig)
+    assert.deepEqual(mergeConfig(defaultConfig, { galaxy: null }), defaultConfig)
+    assert.deepEqual(mergeConfig(defaultConfig, { bits: '0' }), defaultConfig)
+    assert.deepEqual(mergeConfig(defaultConfig, { year: '0' }), defaultConfig)
+    assert.deepEqual(mergeConfig(defaultConfig, { foo: 42 }), defaultConfig)
+  })
+
+  it('other user config values exist in result', () => {
+    assert.deepEqual(mergeConfig(defaultConfig, { chi: 'ba' }), { ...defaultConfig, chi: 'ba' })
+    assert.deepEqual(mergeConfig(defaultConfig, { galaxy: { chi: 'ba' } }), {
+      ...defaultConfig,
+      galaxy: { ...defaultConfig.galaxy, chi: 'ba' },
+    })
+  })
+})
+
+describe('config', () => {
+  beforeEach(() => {
     delete require.cache[require.resolve('../../lib/config')]
     config = require('../../lib/config')
   })
-  describe('initially', function() {
-    it('should be empty', function() {
+  describe('initially', () => {
+    it('should be empty', () => {
       assert.deepEqual(config.get('', null), {})
     })
   })
-  describe('#set() #get()', function() {
-    it('should be set and get a string correctly', function() {
+  describe('set and get methods', () => {
+    it('should be set and get a string correctly', () => {
       config.set('path.to.value', 'Dead Beef')
       assert.deepEqual(config.get('path.to.value', 'null'), 'Dead Beef')
     })
-    it('should be set and get a object correctly', function() {
+    it('should be set and get a object correctly', () => {
       config.set('another', {
         a: 'b',
         c: 0xbb,
@@ -28,7 +62,7 @@ describe('config', function() {
         c: 0xbb,
       })
     })
-    it('should be get a null', function() {
+    it('should be get a null', () => {
       assert.deepEqual(config.get('null.path', null), null)
     })
   })


### PR DESCRIPTION
In previous commits we already have enabled default values for `config` module, however this does not cover redux usage

To make both methods return coherent result, default values are merged to current user config to ensure they are available upon initialization

Features included:
- default value merging
- user config value type check and reset if not match
- `set` and `delete` method supports arrays as path, same behaviour as `lodash`