### PR TITLE
macOS Tray

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Tray, nativeImage, shell } = require('electron')
+const { app, BrowserWindow, ipcMain, nativeImage, shell } = require('electron')
 const path = require('path-extra')
 
 // Environment
@@ -93,7 +93,7 @@ if (dbg.isEnabled()) {
 
 require('./lib/flash')
 
-let mainWindow, appIcon
+let mainWindow
 global.mainWindow = mainWindow = null
 
 // Set FPS limit

--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ const { warn, error } = require('./lib/utils')
 const dbg = require('./lib/debug')
 require('./lib/updater')
 proxy.setMaxListeners(30)
+require('./lib/tray')
 
 // Disable HA
 if (config.get('poi.misc.disablehwaccel', false)) {
@@ -210,18 +211,6 @@ app.on('ready', () => {
     require('./lib/window').closeWindows()
     mainWindow = null
   })
-
-  // Tray icon
-  if (process.platform === 'win32' || process.platform === 'linux') {
-    global.appIcon = appIcon = new Tray(poiIconPath)
-    appIcon.on('click', () => {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore()
-      } else {
-        mainWindow.show()
-      }
-    })
-  }
 
   // devtool
   if (dbg.isEnabled() && config.get('poi.devtool.enable', false)) {

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -145,7 +145,6 @@
   "Safe Mode": "セーフモード",
   "poi is running in safe mode, plugins are not enabled automatically": "poi がセーフモードで実行されている、プラグインは自動的に有効になっていません。",
   "Enter safe mode on next startup": "次回はセーフモードで起動する",
-  "Display tray icon": "トレイのアイコンを表示する",
   "Send data to Google Analytics": "使用統計データを Google Analytics に自動送信する",
   "Current version": "現在のバージョン",
   "Check update of beta version": "ベータ版を確認する",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -145,7 +145,6 @@
   "Safe Mode": "安全模式",
   "poi is running in safe mode, plugins are not enabled automatically": "poi 运行在安全模式下，插件没有自动启用。",
   "Enter safe mode on next startup": "下次启动进入安全模式",
-  "Display tray icon": "显示托盘图标",
   "Send data to Google Analytics": "向 Google Analytics 发送统计数据",
   "Current version": "现在版本",
   "Check update of beta version": "检查测试版更新",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -145,7 +145,6 @@
   "Safe Mode": "安全模式",
   "poi is running in safe mode, plugins are not enabled automatically": "poi 運行在安全模式下，擴展程式沒有自動啓用。",
   "Enter safe mode on next startup": "下次啓動進入安全模式",
-  "Display tray icon": "顯示托盤圖標",
   "Send data to Google Analytics": "向 Google Analytics 傳送統計資料",
   "Current version": "現在版本",
   "Check update of beta version": "檢查測試版更新",

--- a/lib/tray.es
+++ b/lib/tray.es
@@ -1,0 +1,36 @@
+import path from 'path'
+import { app, Tray, systemPreferences } from 'electron'
+
+const getIcon = platform => {
+  if (platform === 'linux') {
+    return 'poi_32x32.png'
+  }
+  if (platform === 'darwin') {
+    if (systemPreferences.isDarkMode()) {
+      return 'poi_ribbon_dark.png'
+    }
+    return 'poi_ribbon_light.png'
+  }
+  return 'poi.ico'
+}
+
+const getIconPath = platform => path.join(global.ROOT, 'assets', 'icons', getIcon(platform))
+
+let tray = null
+app.on('ready', () => {
+  global.appTray = tray = new Tray(getIconPath(process.platform))
+  tray.on('click', () => {
+    if (global.mainWindow?.isMinimized()) {
+      global.mainWindow.restore()
+    } else {
+      global.mainWindow?.show()
+    }
+  })
+  tray.setToolTip(app.getName())
+})
+
+if (process.platform === 'darwin') {
+  systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () => {
+    tray?.setImage(getIconPath(process.platform))
+  })
+}

--- a/views/components/etc/menu.es
+++ b/views/components/etc/menu.es
@@ -416,8 +416,8 @@ if (process.platform === 'darwin') {
   win.setMenu(appMenu)
   win.setAutoHideMenuBar(true)
   win.setMenuBarVisibility(false)
-  if (['win32', 'linux'].includes(process.platform) && window.appIcon) {
-    window.appIcon.setContextMenu(appMenu)
+  if (window.appTray) {
+    window.appTray.setContextMenu(appMenu)
   }
 }
 

--- a/views/components/settings/main/advanced-config/index.es
+++ b/views/components/settings/main/advanced-config/index.es
@@ -39,12 +39,6 @@ const SWITCHES = [
     platform: ['win32'],
   },
   {
-    label: 'Display tray icon',
-    configName: 'poi.linuxTrayIcon',
-    defaultValue: true,
-    platform: ['linux'],
-  },
-  {
     label: 'Enter safe mode on next startup',
     configName: 'poi.misc.safemode',
     defaultValue: false,

--- a/views/env.es
+++ b/views/env.es
@@ -23,7 +23,7 @@ window.PLUGIN_PATH = path.join(window.APPDATA_PATH, 'plugins')
 window.POI_VERSION = remote.getGlobal('POI_VERSION')
 window.SERVER_HOSTNAME = remote.getGlobal('SERVER_HOSTNAME')
 window.MODULE_PATH = remote.getGlobal('MODULE_PATH')
-window.appIcon = remote.getGlobal('appIcon')
+window.appTray = remote.getGlobal('appTray')
 window.isSafeMode = remote.getGlobal('isSafeMode')
 window.isDevVersion = remote.getGlobal('isDevVersion')
 


### PR DESCRIPTION
implement macOS tray

other modifications:
- API rename: `appIcon` -> `appTray`
- remove unused linux `show tray icon` setting

closes #2055 