### PR TITLE
Fix in-game quarter definition.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
+// @ts-check
+
 const _ = require('lodash')
 
+/** @type { jest.ProjectConfig } */
 module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
@@ -7,6 +10,9 @@ module.exports = {
     '^.+\\.(es|ts|tsx)$': 'babel-jest',
   },
   moduleFileExtensions: ['js', 'es', 'json', 'jsx', 'ts', 'tsx', 'node'],
+  moduleNameMapper: {
+    '^views/(.*)': '<rootDir>/views/$1',
+  },
   testMatch: ['**/__tests__/**/*.[ejt]s?(x)', '**/?(*.)+(spec|test).[ejt]s?(x)'],
   setupFilesAfterEnv: ['./setupTests.es'],
   collectCoverageFrom: ['lib', 'views', 'build'].map(dir => `./${dir}/**/*.[ejt]s?(x)`),

--- a/package-lock.json
+++ b/package-lock.json
@@ -3294,6 +3294,15 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "24.0.25",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
+      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^24.3.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@types/glob": "^7.1.1",
     "@types/gulp": "^4.0.6",
     "@types/http-proxy-agent": "^2.0.2",
+    "@types/jest": "^24.0.25",
     "@types/lodash": "^4.14.149",
     "@types/mime": "^2.0.1",
     "@types/moment-timezone": "^0.5.12",

--- a/views/redux/info/__tests__/quests.spec.es
+++ b/views/redux/info/__tests__/quests.spec.es
@@ -1,0 +1,34 @@
+import { getTanakalendarQuarterMonth } from '../quests'
+
+const spec = it
+
+describe('getTanakalendarQuarterMonth', () => {
+  spec('sample of a full year', () => {
+    const mkDate = (year, month) => new Date(`${year}-${month}`)
+    const testCase = (year, month, expected) =>
+      expect(getTanakalendarQuarterMonth(mkDate(year, month))).toStrictEqual(expected)
+
+    const qmBase = getTanakalendarQuarterMonth(mkDate(2019, 1))
+    // this "quarter" is relative, we don't care about its actual value
+    // but will expect the following months to be consistent.
+    const q0 = qmBase[0]
+    // expect the first month of a year to be the second month in that quarter.
+    expect(qmBase[1]).toBe(1)
+
+    testCase(2019, 2, [q0, 2])
+
+    testCase(2019, 3, [q0 + 1, 0])
+    testCase(2019, 4, [q0 + 1, 1])
+    testCase(2019, 5, [q0 + 1, 2])
+
+    testCase(2019, 6, [q0 + 2, 0])
+    testCase(2019, 7, [q0 + 2, 1])
+    testCase(2019, 8, [q0 + 2, 2])
+
+    testCase(2019, 9, [q0 + 3, 0])
+    testCase(2019, 10, [q0 + 3, 1])
+    testCase(2019, 11, [q0 + 3, 2])
+
+    testCase(2019, 12, [q0 + 4, 0])
+  })
+})

--- a/views/redux/info/quests.es
+++ b/views/redux/info/quests.es
@@ -1,7 +1,18 @@
 /* global ROOT, APPDATA_PATH */
 import CSON from 'cson'
 import { join } from 'path-extra'
-import { map, sortBy, mapValues, forEach, values, fromPairs, countBy, get, size } from 'lodash'
+import {
+  map,
+  sortBy,
+  mapValues,
+  forEach,
+  values,
+  fromPairs,
+  countBy,
+  get,
+  size,
+  isEqual,
+} from 'lodash'
 
 import FileWriter from 'views/utils/file-writer'
 import { copyIfSame, arraySum } from 'views/utils/tools'
@@ -78,15 +89,20 @@ function isDifferentMonth(time1, time2) {
   )
 }
 
-const getQuarter = time => {
-  const month = time.getUTCMonth()
-  return month - (month % 3)
+// returns [q,m], where q uniquely identifies a Tanaka quarter,
+// and m <- [0,1,2] describes the relative month within that quarter.
+export const getTanakalendarQuarterMonth = time => {
+  const y = time.getUTCFullYear()
+  // yup, month apparently starts at 0
+  const m = time.getUTCMonth() + 1
+  const v = y * 12 + m
+  return [Math.floor(v / 3), v % 3]
 }
 
 const isDifferentQuarter = (time1, time2) => {
   const date1 = new Date(time1 + 14400000)
   const date2 = new Date(time2 + 14400000)
-  return getQuarter(date1) !== getQuarter(date2) || date1.getUTCFullYear() != date2.getUTCFullYear()
+  return !isEqual(getTanakalendarQuarterMonth(date1), getTanakalendarQuarterMonth(date2))
 }
 
 function newQuestRecord(id, questGoals) {


### PR DESCRIPTION
Fixes #2081.

Make our quest quarter agree with the in-game one,
this allows us to fix the issue where quarterly quests are reset
on incorrect time.