### PR TITLE
Allow caching of gadget_html5 files

### DIFF
--- a/lib/proxy.es
+++ b/lib/proxy.es
@@ -35,6 +35,9 @@ const isStaticResource = (pathname, hostname) => {
   if (pathname.startsWith('/gadget/')) {
     return true
   }
+  if (pathname.startsWith('/gadget_html5/')) {
+    return true
+  }
   if (pathname.startsWith('/kcscontents/')) {
     return true
   }


### PR DESCRIPTION
Phase 2 introduced `gadget_html5` in addition to (instead of?) `gadget` on `203.104.209.7`.

Right now this can be used to avoid current IP restrictions without VPN/proxy (i.e., by creating `~/.config/poi/MyCache/KanColle/{gadget_html5,kcscontents}`).