### PR TITLE
auto-adjust when devtool is opened.

### DIFF
--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -219,6 +219,9 @@ export class PoiControl extends Component {
   handleOpenDevTools = () => {
     // openFocusedWindowDevTools()
     remote.getCurrentWindow().openDevTools({ mode: 'detach' })
+    setTimeout(() => {
+      getStore('layout.webview.ref').executeJavaScript('window.align()')
+    }, 100)
   }
 
   handleOpenWebviewDevTools = () => {


### PR DESCRIPTION
Getting tired of clicking adjust after devtool is opened,
therefore some simple hack.

For whatever reason this won't work first time after launch,
but it'll work for consequent opens.