### PR TITLE
Allow custom cache changes to be recognized by the browser

### DIFF
--- a/lib/proxy.es
+++ b/lib/proxy.es
@@ -378,15 +378,15 @@ class Proxy extends EventEmitter {
     })
 
   useCache = async (req, res, cacheFile) => {
-    const stats = await fs.stat(cacheFile)
+    const mtime = (await fs.stat(cacheFile)).mtime.toGMTString()
     if (
       req.headers['if-modified-since'] &&
-      new Date(req.headers['if-modified-since']) >= stats.mtime
+      new Date(req.headers['if-modified-since']) >= new Date(mtime)
     ) {
       // Cache is new
       res.writeHead(304, {
         Server: 'nginx',
-        'Last-Modified': stats.mtime.toGMTString(),
+        'Last-Modified': mtime,
       })
       res.end()
     } else {
@@ -396,7 +396,8 @@ class Proxy extends EventEmitter {
         Server: 'nginx',
         'Content-Length': data.length,
         'Content-Type': mime.getType(cacheFile),
-        'Last-Modified': stats.mtime.toGMTString(),
+        'Last-Modified': mtime,
+        'Cache-Control': 'max-age=0',
       })
       res.end(data)
     }


### PR DESCRIPTION
There are two problems in [`useCache`](https://github.com/poooi/poi/blob/master/lib/proxy.es#L380) that prevent custom cache  updates from propagating to the browser (without clearing the whole browser cache):

- `if-modified-since` is not being sent, setting `cache-control` to `max-age=0` allows browser and proxy to always communicate changes via `if-modified-since`.
- `new Date(req.headers['if-modified-since']) >= stats.mtime` comparison doesn't always work as `mtime` (`Date`) can have more resolution (that is, subsecond resolution) than parsed `req.headers['if-modified-since']` (up to a second resolution).