### PR TITLE
fix: allow caching /html/ files

### DIFF
--- a/lib/proxy.es
+++ b/lib/proxy.es
@@ -41,6 +41,9 @@ const isStaticResource = (pathname, hostname) => {
   if (pathname.startsWith('/kcscontents/')) {
     return true
   }
+  if (pathname.startsWith('/html/')) {
+    return true
+  }
   if (hostname.match('kanpani.jp')) {
     return true
   }


### PR DESCRIPTION
To add to https://github.com/poooi/poi/pull/2281, there are also [those](https://github.com/kcwiki/cache/tree/master/html) files, which can be used during maintenance (or ban) times by https://github.com/kcwiki/poi-plugin-let-me-in (currently shows 403 in maintenance).