### PR TITLE
Disable spellcheck.

### DIFF
--- a/app.js
+++ b/app.js
@@ -195,6 +195,7 @@ app.on('ready', () => {
       zoomFactor: config.get('poi.appearance.zoom', 1),
       enableRemoteModule: true,
       contextIsolation: false,
+      spellcheck: false,
       // experimentalFeatures: true,
     },
     backgroundColor: '#00000000',


### PR DESCRIPTION
This feature is basically useless and a waste of resource - there are only a handful of places that have non-numeric textbox and we either put url or katakana in there that I doubt spell check can produce any sensible result.