### PR TITLE
暴力修复选择器“原始舰娘id”常量列表中没有宗谷

### DIFF
--- a/views/utils/selectors.es
+++ b/views/utils/selectors.es
@@ -486,7 +486,8 @@ export const shipRemodelInfoSelector = createSelector(constSelector, ({ $ships }
   })
 
   // all those that has nothing pointing to them are originals
-  const originMstIds = mstIds.filter((mstId) => !afterMstIdSet.has(mstId))
+  // except apino 699 Soya, who has a uroboros-esque "circular" remodel chain
+  const originMstIds = mstIds.filter((mstId) => !afterMstIdSet.has(mstId)).concat(699)
 
   /*
        remodelChains[originMstId] = <RemodelChain>


### PR DESCRIPTION
看起来这个bug导致了https://github.com/poooi/poi/issues/2379（插件中使用了自带的选择器），但合并这个请求不一定可以修复；

简单来说，宗谷的改造链是个环，而选择器中列表是靠寻找没有入度的舰娘apiid确定的（原理是没有舰娘可以被改造成原始舰娘），对宗谷来说这种筛选法显然不适用。

这种修复方法非常暴力，但我能想到的更普适另一种方法是“如果在`afterMstIdSet`种探测到环，那么移除其中`api_sortno`最小的”，不过我不熟悉es6，得学习一下怎么高效地实现这个方法……