### PR TITLE
fix: Cannot capture page in MacOS

### DIFF
--- a/views/components/info/control.es
+++ b/views/components/info/control.es
@@ -105,7 +105,6 @@ export class PoiControl extends Component {
       height: Math.floor(height * devicePixelRatio),
     }
     getStore('layout.webview.ref')
-      .getWebContents()
       .capturePage(rect)
       .then((image) => {
         this.handleScreenshotCaptured({


### PR DESCRIPTION
Tested:
Windows 10
MacOS Big Sur