### PR TITLE
fix: Add normal 5 inch Mk.30 to aaci 35/36

### DIFF
--- a/views/utils/aaci.es
+++ b/views/utils/aaci.es
@@ -482,7 +482,8 @@ declareAACI({
   equipsValid: hasAtLeast(is5InchSingleGunMountMk30PlusGFCS, 2),
 })
 
-const is5InchSingleGunMountMk30 = equip => equip.api_slotitem_id === 313
+const is5InchSingleGunMountMk30OrKai = equip => (equip.api_slotitem_id === 284 || equip.api_slotitem_id === 313)
+const is5InckSingleGunMountMk30Kai = equip => equip.apt_slotitem_id === 313
 
 declareAACI({
   name: ['Johnston', 'Fletcher'],
@@ -492,7 +493,7 @@ declareAACI({
   shipValid: isFletcherClassOrKai,
   equipsValid: validAll(
     hasSome(is5InchSingleGunMountMk30PlusGFCS),
-    hasSome(is5InchSingleGunMountMk30),
+    hasSome(is5InchSingleGunMountMk30OrKai),
   ),
 })
 
@@ -504,7 +505,7 @@ declareAACI({
   fixed: 6,
   modifier: 1.55,
   shipValid: isFletcherClassOrKai,
-  equipsValid: validAll(hasAtLeast(is5InchSingleGunMountMk30, 2), hasSome(isGFCSMk37)),
+  equipsValid: validAll(hasAtLeast(is5InchSingleGunMountMk30OrKai, 2), hasSome(isGFCSMk37)),
 })
 
 declareAACI({
@@ -513,7 +514,7 @@ declareAACI({
   fixed: 4,
   modifier: 1.55,
   shipValid: isFletcherClassOrKai,
-  equipsValid: hasAtLeast(is5InchSingleGunMountMk30, 2),
+  equipsValid: hasAtLeast(is5InckSingleGunMountMk30Kai, 2),
 })
 
 // id 38~41: Atlanta


### PR DESCRIPTION
Normal 5 inch Mk.30 should be able to trigger AACI 35 and 36 as well as per enwiki [https://en.kancollewiki.net/Aerial_Combat#Anti-Air_Cut-in](https://en.kancollewiki.net/Aerial_Combat#Anti-Air_Cut-in)

![image](https://user-images.githubusercontent.com/39070658/204219608-87dc62f7-19bf-424c-a238-8bf9404d2b5e.png)

![2022-11-27T23 58 53](https://user-images.githubusercontent.com/39070658/204219765-7b271278-14bf-4271-8dc8-fbcc4eb307ac.png)
