### PR TITLE
Add option to display detailed information in overview

### DIFF
--- a/i18n/setting/en-US.json
+++ b/i18n/setting/en-US.json
@@ -107,6 +107,7 @@
   "Vibrance": "Vibrance",
   "Custom background": "Custom background",
   "Use Gridded Plugin Menu": "Use Gridded Plugin Menu",
+  "Summarize fleet info in overview": "Summarize fleet info in overview",
   "Show shipgirl avatar": "Show shipgirl avatar",
   "file": "file",
   "Experimental": "Experimental",

--- a/i18n/setting/en-US.json
+++ b/i18n/setting/en-US.json
@@ -107,7 +107,7 @@
   "Vibrance": "Vibrance",
   "Custom background": "Custom background",
   "Use Gridded Plugin Menu": "Use Gridded Plugin Menu",
-  "Summarize fleet info in overview": "Summarize fleet info in overview",
+  "Display detailed fleet info in main panel": "Display detailed fleet info in main panel",
   "Show shipgirl avatar": "Show shipgirl avatar",
   "file": "file",
   "Experimental": "Experimental",

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -87,6 +87,7 @@
   "Use SVG Icon": "SVGアイコンを使用する",
   "Enable Smooth Transition": "タブの切り替えをスムースに表示する",
   "Use Gridded Plugin Menu": "プラグインメニューをグリッド仕様に設定する",
+  "Summarize fleet info in overview": "一覧の艦隊情報を簡略化する",
   "Plugin update": "プラグイン更新",
   "PluginUpdateMsg": "は新しいバージョンがあります。アップデートを行って下さい。",
   "Check Update": "更新を確認",

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -87,7 +87,7 @@
   "Use SVG Icon": "SVGアイコンを使用する",
   "Enable Smooth Transition": "タブの切り替えをスムースに表示する",
   "Use Gridded Plugin Menu": "プラグインメニューをグリッド仕様に設定する",
-  "Summarize fleet info in overview": "一覧の艦隊情報を簡略化する",
+  "Display detailed fleet info in main panel": "一覧に詳細な艦隊情報を表示する",
   "Plugin update": "プラグイン更新",
   "PluginUpdateMsg": "は新しいバージョンがあります。アップデートを行って下さい。",
   "Check Update": "更新を確認",

--- a/i18n/setting/ko-KR.json
+++ b/i18n/setting/ko-KR.json
@@ -87,7 +87,7 @@
   "Use SVG Icon": "SVG 아이콘 사용",
   "Enable Smooth Transition": "탭을 전환할 때 컨텐츠를 부드럽게 표시",
   "Use Gridded Plugin Menu": "플러그인 메뉴를 그리드 방식으로 설정",
-  "Summarize fleet info in overview": "개요에 단순화된 차량 세부 정보",
+  "Display detailed fleet info in main panel": "주 패널에 상세한 함대 정보 표시",
   "Plugin update": "플러그인 업데이트",
   "PluginUpdateMsg": "의 새로운 버전이 있습니다. 업데이트 해주세요.",
   "Check Update": "업데이트 확인",

--- a/i18n/setting/ko-KR.json
+++ b/i18n/setting/ko-KR.json
@@ -87,6 +87,7 @@
   "Use SVG Icon": "SVG 아이콘 사용",
   "Enable Smooth Transition": "탭을 전환할 때 컨텐츠를 부드럽게 표시",
   "Use Gridded Plugin Menu": "플러그인 메뉴를 그리드 방식으로 설정",
+  "Summarize fleet info in overview": "개요에 단순화된 차량 세부 정보",
   "Plugin update": "플러그인 업데이트",
   "PluginUpdateMsg": "의 새로운 버전이 있습니다. 업데이트 해주세요.",
   "Check Update": "업데이트 확인",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -87,6 +87,7 @@
   "Use SVG Icon": "使用高清图标",
   "Enable Smooth Transition": "启用平滑切换动画",
   "Use Gridded Plugin Menu": "使用网格式插件菜单",
+  "Summarize fleet info in overview": "概览中简化舰队详情",
   "Plugin update": "插件更新",
   "PluginUpdateMsg": "有新版本。请更新插件。",
   "Check Update": "检查更新",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -87,7 +87,7 @@
   "Use SVG Icon": "使用高清图标",
   "Enable Smooth Transition": "启用平滑切换动画",
   "Use Gridded Plugin Menu": "使用网格式插件菜单",
-  "Summarize fleet info in overview": "概览中简化舰队详情",
+  "Display detailed fleet info in main panel": "在主面板显示详细的舰队信息",
   "Plugin update": "插件更新",
   "PluginUpdateMsg": "有新版本。请更新插件。",
   "Check Update": "检查更新",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -87,6 +87,7 @@
   "Use SVG Icon": "使用高畫質圖示",
   "Enable Smooth Transition": "啟用平滑切換動畫",
   "Use Gridded Plugin Menu": "使用網格式插件選單",
+  "Summarize fleet info in overview": "概覽中簡化艦隊詳情",
   "Plugin update": "擴展程式更新",
   "PluginUpdateMsg": "有新版本。請更新擴展程式。",
   "Check Update": "檢查更新",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -87,7 +87,7 @@
   "Use SVG Icon": "使用高畫質圖示",
   "Enable Smooth Transition": "啟用平滑切換動畫",
   "Use Gridded Plugin Menu": "使用網格式插件選單",
-  "Summarize fleet info in overview": "概覽中簡化艦隊詳情",
+  "Display detailed fleet info in main panel": "在主面板顯示詳細的艦隊資訊",
   "Plugin update": "擴展程式更新",
   "PluginUpdateMsg": "有新版本。請更新擴展程式。",
   "Check Update": "檢查更新",

--- a/views/components/main/parts/mini-ship/mini-ship-pane.es
+++ b/views/components/main/parts/mini-ship/mini-ship-pane.es
@@ -22,14 +22,14 @@ export const PaneBodyMini = connect(() => {
   return (state, { fleetId }) => ({
     shipsId: fleetShipsIdSelectorFactory(fleetId)(state),
     enableAvatar: get(state, 'config.poi.appearance.avatar', true),
-    summarizeFleetInfo: get(state, 'config.poi.appearance.summarizeFleetInfo', true),
+    enableOverviewFleetDetail: get(state, 'config.poi.appearance.enableOverviewFleetDetail', false),
     width: miniShipRowWidthSelector(state),
   })
-})(({ fleetId, shipsId, enableAvatar, summarizeFleetInfo, width }) => (
+})(({ fleetId, shipsId, enableAvatar, enableOverviewFleetDetail, width }) => (
   <>
-    <FleetStat fleetId={fleetId} isMini={summarizeFleetInfo} />
+    <FleetStat fleetId={fleetId} isMini={!enableOverviewFleetDetail} />
     <ShipDetailsMini className="ship-details-mini">
-      {(summarizeFleetInfo) ? (shipsId || []).map((shipId, i) => (
+      {(!enableOverviewFleetDetail) ? (shipsId || []).map((shipId, i) => (
         <MiniShipRow
           key={shipId}
           shipId={shipId}

--- a/views/components/main/parts/mini-ship/mini-ship-pane.es
+++ b/views/components/main/parts/mini-ship/mini-ship-pane.es
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { ShipRow } from '../../../ship/ship-item'
 import { MiniShipRow, MiniSquardRow } from './mini-ship-item'
 import React, { Fragment } from 'react'
 import { get } from 'lodash'
@@ -21,14 +22,22 @@ export const PaneBodyMini = connect(() => {
   return (state, { fleetId }) => ({
     shipsId: fleetShipsIdSelectorFactory(fleetId)(state),
     enableAvatar: get(state, 'config.poi.appearance.avatar', true),
+    summarizeFleetInfo: get(state, 'config.poi.appearance.summarizeFleetInfo', true),
     width: miniShipRowWidthSelector(state),
   })
-})(({ fleetId, shipsId, enableAvatar, width }) => (
+})(({ fleetId, shipsId, enableAvatar, summarizeFleetInfo, width }) => (
   <>
-    <FleetStat fleetId={fleetId} isMini={true} />
+    <FleetStat fleetId={fleetId} isMini={summarizeFleetInfo} />
     <ShipDetailsMini className="ship-details-mini">
-      {(shipsId || []).map((shipId, i) => (
+      {(summarizeFleetInfo) ? (shipsId || []).map((shipId, i) => (
         <MiniShipRow
+          key={shipId}
+          shipId={shipId}
+          enableAvatar={enableAvatar}
+          compact={width < 240}
+        />
+      )) : (shipsId || []).map((shipId, i) => (
+        <ShipRow
           key={shipId}
           shipId={shipId}
           enableAvatar={enableAvatar}

--- a/views/components/settings/display/theme-config.es
+++ b/views/components/settings/display/theme-config.es
@@ -56,9 +56,9 @@ const SWITCHES = [
     defaultValue: true,
   },
   {
-    label: 'Summarize fleet info in overview',
-    configName: 'poi.appearance.summarizeFleetInfo',
-    defaultValue: true,
+    label: 'Display detailed fleet info in main panel',
+    configName: 'poi.appearance.enableOverviewFleetDetail',
+    defaultValue: false,
   },
   {
     label: 'Show shipgirl avatar',

--- a/views/components/settings/display/theme-config.es
+++ b/views/components/settings/display/theme-config.es
@@ -56,6 +56,11 @@ const SWITCHES = [
     defaultValue: true,
   },
   {
+    label: 'Summarize fleet info in overview',
+    configName: 'poi.appearance.summarizeFleetInfo',
+    defaultValue: true,
+  },
+  {
     label: 'Show shipgirl avatar',
     configName: 'poi.appearance.avatar',
     defaultValue: false,


### PR DESCRIPTION
This PR adds the configuration under appearance, and default to the current behavior.

When disabled, the overview panel will display the same detailed information as the fleet panel, which include equipment information and fleet stats summary, etc.

Agreed how it looks depends on the screen space, but hopefully leaving it as a configuration it's not too bad

<img width="527" alt="Screenshot 2023-10-25 at 9 38 07 PM" src="https://github.com/poooi/poi/assets/41968256/9293dfc3-8e71-48d3-b330-cad0d1a8bbed">



<img width="505" alt="Screenshot 2023-10-25 at 9 57 55 PM" src="https://github.com/poooi/poi/assets/41968256/f13e5d3a-e682-47ab-b58b-129cbad13888">

