### PR TITLE
Disable tab key to avoid moving the window accidentally

### DIFF
--- a/lib/shortcut.ts
+++ b/lib/shortcut.ts
@@ -14,6 +14,10 @@ const registerShortcut = (acc: Electron.Accelerator, desc: string, func: () => v
   }
 }
 
+const disableTabKey = () => {
+  registerShortcut('Tab', 'Tab Key', () => (console.log("Ignored tab key")))
+}
+
 const registerBossKey = () => {
   const accelerator = config.get('poi.shortcut.bosskey', '')
   if (accelerator)
@@ -23,6 +27,8 @@ const registerBossKey = () => {
 
 export default {
   register: () => {
+    disableTabKey()
+
     if (process.platform !== 'darwin') {
       registerBossKey()
     }


### PR DESCRIPTION
Not sure if this is universal but I have noticed that pressing tab would lock onto the element below the main canvas, this used to be fixable by running the auto adjust but that has been not working for a while, so a workaround would be disabling tab key in game to avoid getting stuck on losing the top 10% of the game screen. Usually it is not a big deal but it is large enough to blocker the top banner or airborne deployment..

<img width="1205" alt="Screenshot 2023-10-25 at 11 49 12 PM" src="https://github.com/poooi/poi/assets/41968256/462b26b7-1d9f-4d63-b4be-3ab9378f938d">

(I remember I saw a similar issue/request a long time ago but can't find any somehow)
