### PR TITLE
fix: 通常海域多段MapHp显示不正确

### DIFF
--- a/views/utils/selectors.es
+++ b/views/utils/selectors.es
@@ -62,9 +62,9 @@ function getMapHp(map, $map) {
     const { api_now_maphp, api_max_maphp, api_gauge_type } = map.api_eventmap
     return [api_now_maphp, api_max_maphp, api_gauge_type]
   }
-  const maxCount = $map.api_required_defeat_count
+  const maxCount = map.api_required_defeat_count
   if (!maxCount) return
-  const nowCount = map.api_defeat_count || maxCount
+  const nowCount = map.api_defeat_count ?? maxCount
   const nowHp = maxCount - nowCount
   return [nowHp, maxCount, undefined]
 }


### PR DESCRIPTION
`const maxCount = $map.api_required_defeat_count` 改为 `const maxCount = map.api_required_defeat_count`

‘@@Response/kcsapi/api_start2/getData’ --> api_mst_mapinfo 中的 api_required_defeat_count 固定为第一阶段的击破次数
‘@@Response/kcsapi/api_get_member/mapinfo’ --> api_map_info 中的 api_required_defeat_count 会随着阶段改变而改变

`const nowCount = map.api_defeat_count || maxCount` 改为 `const nowCount = map.api_defeat_count ?? maxCount`

当 map.api_defeat_count 值为 0 时会误判而不显示海域血量条