### PR TITLE
Fix non-sticky alerts in notification area

### DIFF
--- a/views/services/alert.ts
+++ b/views/services/alert.ts
@@ -6,46 +6,21 @@ function dispatchAlertEvent(value: Message) {
   messageInstance.emit(value)
 }
 
-const log = (msg: string, options: Message['options']) => {
+const mkAlert = (type: string, priority: number) => (msg: string, options: Message['options']) => {
   const value = {
     content: msg,
-    type: 'default',
-    priority: 0,
+    type,
+    priority,
     stickyFor: DEFAULT_STICKYFOR,
     options,
   }
   dispatchAlertEvent(value)
 }
-const success = (msg: string, options: Message['options']) => {
-  const value = {
-    content: msg,
-    type: 'success',
-    priority: 1,
-    stickyFor: DEFAULT_STICKYFOR,
-    options,
-  }
-  dispatchAlertEvent(value)
-}
-const warn = (msg: string, options: Message['options']) => {
-  const value = {
-    content: msg,
-    type: 'warning',
-    priority: 2,
-    stickyFor: DEFAULT_STICKYFOR,
-    options,
-  }
-  dispatchAlertEvent(value)
-}
-const error = (msg: string, options: Message['options']) => {
-  const value = {
-    content: msg,
-    type: 'danger',
-    priority: 4,
-    stickyFor: DEFAULT_STICKYFOR,
-    options,
-  }
-  dispatchAlertEvent(value)
-}
+
+const log = mkAlert('default', 0)
+const success = mkAlert('success', 1)
+const warn = mkAlert('warning', 2)
+const error = mkAlert('danger', 4)
 
 // @ts-expect-error backward compatibility
 window.log = log

--- a/views/services/alert.ts
+++ b/views/services/alert.ts
@@ -6,43 +6,43 @@ function dispatchAlertEvent(value: Message) {
   messageInstance.emit(value)
 }
 
-const log = (msg: string, options: Partial<Message>) => {
+const log = (msg: string, options: Message['options']) => {
   const value = {
     content: msg,
     type: 'default',
     priority: 0,
     stickyFor: DEFAULT_STICKYFOR,
-    ...options,
+    options,
   }
   dispatchAlertEvent(value)
 }
-const success = (msg: string, options: Partial<Message>) => {
+const success = (msg: string, options: Message['options']) => {
   const value = {
     content: msg,
     type: 'success',
     priority: 1,
     stickyFor: DEFAULT_STICKYFOR,
-    ...options,
+    options,
   }
   dispatchAlertEvent(value)
 }
-const warn = (msg: string, options: Partial<Message>) => {
+const warn = (msg: string, options: Message['options']) => {
   const value = {
     content: msg,
     type: 'warning',
     priority: 2,
     stickyFor: DEFAULT_STICKYFOR,
-    ...options,
+    options,
   }
   dispatchAlertEvent(value)
 }
-const error = (msg: string, options: Partial<Message>) => {
+const error = (msg: string, options: Message['options']) => {
   const value = {
     content: msg,
     type: 'danger',
     priority: 4,
     stickyFor: DEFAULT_STICKYFOR,
-    ...options,
+    options,
   }
   dispatchAlertEvent(value)
 }


### PR DESCRIPTION
`{dontReserve: true}` is not actually being applied in many cases as it's not passed down properly (see diffs).

Tested manually 
![2025-04-23_17-27](https://github.com/user-attachments/assets/11227b5d-c7cc-4efd-9ff5-069204c8b6a9)
