### PR TITLE
Support `api_req_hensei/preset_order_change` operation.

### DIFF
--- a/views/redux/info/__tests__/presets.spec.ts
+++ b/views/redux/info/__tests__/presets.spec.ts
@@ -1,0 +1,72 @@
+import _ from 'lodash'
+import reducer from '../presets'
+
+const spec = it
+
+// Note: partial definitions containing only essentials.
+interface PresetDeck {
+  api_preset_no: number,
+  api_name: string,
+  api_ship: Array<number>,
+}
+
+type Decks = Record<number, PresetDeck>
+
+interface PresetsState {
+  api_max_num: number,
+  api_deck: Decks,
+}
+
+describe('presets reducer', () => {
+  const mkDeck = (): Decks => ({
+    1: { api_preset_no: 1, api_name: 'ps 1', api_ship: [114, 514, 1919, 810_0721, -1, -1, -1] },
+    4: { api_preset_no: 4, api_name: 'ps 4', api_ship: [1, 2, 3, 4, 5, 6, -1] },
+    12: { api_preset_no: 12, api_name: 'ps 12', api_ship: [1, 2, 3, -1, -1, -1, -1] }
+  })
+  const mkInitState = (): PresetsState => ({
+    ...reducer(undefined, { type: '@@INIT' }),
+    api_deck: mkDeck(),
+  })
+
+  const mkAction = (src: number | string, dst: number | string) => ({
+    type: '@@Response/kcsapi/api_req_hensei/preset_order_change',
+    postBody: {
+      api_verno: '1',
+      api_preset_from: String(src),
+      api_preset_to: String(dst),
+    },
+  })
+
+  const expectApiPresetNoConsistency = (state: PresetsState) => _.forOwn(state.api_deck, (value, key) => {
+    expect(typeof value.api_preset_no).toBe('number')
+    expect(value.api_preset_no).toBe(parseInt(key, 10))
+  })
+
+  describe('api_req_hensei/preset_order_change', () => {
+    spec('swap existing presets', () => {
+      const mut = reducer(mkInitState(), mkAction(1, 12))
+      expectApiPresetNoConsistency(mut)
+      expect(_.get(mut.api_deck, ['12', 'api_name'])).toBe('ps 1')
+      expect(_.get(mut.api_deck, ['1', 'api_name'])).toBe('ps 12')
+    })
+
+    spec('swap existing into empty', () => {
+      const mut = reducer(mkInitState(), mkAction(4, 2))
+      expectApiPresetNoConsistency(mut)
+      expect(_.get(mut.api_deck, ['2', 'api_name'])).toBe('ps 4')
+      expect(_.get(mut.api_deck, ['4'])).toBeUndefined()
+    })
+
+    spec('swap empty into existing (no UI coverage)', () => {
+      const mut = reducer(mkInitState(), mkAction(16, 12))
+      expectApiPresetNoConsistency(mut)
+      expect(_.get(mut.api_deck, ['12'])).toBeUndefined()
+      expect(_.get(mut.api_deck, ['16', 'api_name'])).toBe('ps 12')
+    })
+
+    spec('noop', () =>
+      expect(
+        reducer(mkInitState(), mkAction(5, 5))
+      ).toStrictEqual(mkInitState()))
+  })
+})

--- a/views/redux/info/presets.es
+++ b/views/redux/info/presets.es
@@ -29,6 +29,44 @@ const reducer = (state = initState, action) => {
         api_deck: omit(state.api_deck, api_preset_no),
       }
     }
+    case '@@Response/kcsapi/api_req_hensei/preset_order_change': {
+      // This action is triggered by dragging one preset (api_preset_from)
+      // to another preset position (api_preset_to).
+      // Note that we are implementing as if both values may not exist, just to be safe.
+      const { api_preset_from, api_preset_to } = postBody
+
+      const vFrom = state.api_deck[api_preset_from]
+      const vTo = state.api_deck[api_preset_to]
+
+      if (!vFrom && !vTo) {
+        // none
+        return state
+      }
+
+      const newDeck = {...state.api_deck}
+      if (vFrom && vTo) {
+        // both
+        newDeck[api_preset_from] = vTo
+        newDeck[api_preset_to] = vFrom
+      } else if (vFrom) {
+        delete newDeck[api_preset_from]
+        newDeck[api_preset_to] = vFrom
+      } else {
+        // vTo has value (this should usually not happen due to UI restriction)
+        delete newDeck[api_preset_to]
+        newDeck[api_preset_from] = vTo
+      }
+
+      // fix api_preset_no consistency post-swap.
+      if (vFrom) {
+        vFrom.api_preset_no = parseInt(api_preset_to, 10)
+      }
+      if (vTo) {
+        vTo.api_preset_no = parseInt(api_preset_from, 10)
+      }
+
+      return {...state, api_deck: newDeck}
+    }
   }
   return state
 }


### PR DESCRIPTION
Turns out you can drag presets around in UI to rearrange them.