### PR TITLE
Implement fleet qualification checkmark.

### DIFF
--- a/views/components/main/parts/task-panel.tsx
+++ b/views/components/main/parts/task-panel.tsx
@@ -1,4 +1,3 @@
-import type { QuestRecord, SubgoalRecord } from 'views/redux/info/quests'
 import type { RootState } from 'views/redux/reducer-factory'
 
 import { Tag, Intent, ResizeSensor, Tooltip } from '@blueprintjs/core'
@@ -12,9 +11,16 @@ import ScrollShadow from 'views/components/etc/scroll-shadow'
 import { config } from 'views/env'
 import i18next from 'views/env-parts/i18next'
 import {
+  satisfyShip,
+  type QuestGoalSubgoal,
+  type QuestRecord,
+  type SubgoalRecord,
+} from 'views/redux/info/quests'
+import {
   configLayoutSelector,
   configReverseLayoutSelector,
   extensionSelectorFactory,
+  getFleetInfo,
 } from 'views/utils/selectors'
 import { escapeI18nKey } from 'views/utils/tools'
 
@@ -266,6 +272,55 @@ const TaskRow = ({ idx, quest, colwidth }: { idx: number; quest: Quest; colwidth
     (state: RootState) => questPluginExtensionSelector(state)?.quests?.[quest.api_no]?.wiki_id,
   )
 
+  // selects 1-based fleet indices listing qualifiying fleets.
+  const qualifyingFleets = useSelector((state: RootState) => {
+    const questGoal = state.info?.quests?.questGoals?.[quest.api_no]
+    if (!questGoal || typeof questGoal !== 'object') return null
+
+    const subgoals: QuestGoalSubgoal[] = Object.entries(questGoal)
+      // only cares about non-metadata key stuff
+      .filter(([k]) => k !== 'type' && k !== 'fuzzy' && k !== 'resetInterval')
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- v is QuestGoalSubgoal after filtering metadata keys above
+      .map(([, v]) => v as QuestGoalSubgoal)
+    if (subgoals.length === 0) return null
+
+    /*
+      to reduce noise, checkmark is only shown when quest actually cares about the fleet in any way.
+
+      The field list below shall match satisfyShip() in views/redux/info/quests.ts.
+      falling out of sync may miss a qualifying fleet, but the actual quest
+      indicator counter is unaffected, as this only serves as a display hint.
+     */
+    const hasShipConstraints = subgoals.some(
+      (sg) =>
+        !!(
+          sg.flagship ||
+          sg.secondship ||
+          sg.escortship ||
+          sg.flagshiptype ||
+          sg.escortshiptype ||
+          sg.flagshipclass ||
+          sg.escortshipclass ||
+          sg.banshiptype ||
+          sg.fleetlimit
+        ),
+    )
+    if (!hasShipConstraints) return null
+
+    const qualifying: number[] = []
+    const maxFleets = state.info?.fleets?.length ?? 0
+    for (let fi = 0; fi < maxFleets; ++fi) {
+      const fleet = state.info?.fleets?.[fi]
+      if (!fleet) continue
+
+      const deckShipId = fleet.api_ship ?? []
+      const allPass = subgoals.every((sg) => satisfyShip(sg, getFleetInfo(deckShipId, state)))
+      if (allPass) qualifying.push(fi + 1)
+    }
+
+    return qualifying.length > 0 ? qualifying : null
+  })
+
   const wikiIdPrefix = wikiId ? `${wikiId} - ` : ''
   const questName = quest?.api_title
     ? t(`resources:${quest.api_title}`, { context: quest.api_no?.toString() })
@@ -279,6 +334,16 @@ const TaskRow = ({ idx, quest, colwidth }: { idx: number; quest: Quest; colwidth
   const progressIntent = record ? getIntentByPercent(count / required) : getIntentByProgress(quest)
   const progressLabel = record ? `${count} / ${required}` : progressLabelText(quest)
   const progressOverlay = record ? getToolTip(record) : []
+  /*
+    renders a line like "✔ 1, 2, 4" after the subgoal counters.
+
+    - numbers are qualifying fleets starting from 1.
+    - to avoid making UI busy, this only shows when:
+      + at least one fleet qualifies
+      + quest itself requires any non-trivial qualifications
+   */
+  const fleetOverlay =
+    qualifyingFleets && qualifyingFleets.length > 0 ? [`✔ ${qualifyingFleets.join(', ')}`] : []
 
   return (
     <TaskRowBase
@@ -297,7 +362,7 @@ const TaskRow = ({ idx, quest, colwidth }: { idx: number; quest: Quest; colwidth
       }
       rightLabel={progressLabel}
       rightIntent={progressIntent}
-      rightOverlay={progressOverlay}
+      rightOverlay={[...progressOverlay, ...fleetOverlay]}
       colwidth={colwidth}
     />
   )

--- a/views/redux/info/quests.ts
+++ b/views/redux/info/quests.ts
@@ -340,7 +340,7 @@ function satisfyGoal(
   return !unsatisfy
 }
 
-function satisfyShip(goal: QuestGoalSubgoal, options: QuestOptions): boolean {
+export function satisfyShip(goal: QuestGoalSubgoal, options: QuestOptions): boolean {
   if (
     goal.flagship &&
     ((options?.shipname?.length ?? 0) < 1 ||

--- a/views/redux/middlewares/quests-cross-slice.ts
+++ b/views/redux/middlewares/quests-cross-slice.ts
@@ -1,6 +1,7 @@
 import type { Middleware } from 'redux'
 
 import { countBy, get } from 'lodash'
+import { getFleetInfo } from 'views/utils/selectors'
 
 import type { RootState } from '../reducer-factory'
 
@@ -20,23 +21,6 @@ import {
   createInfoQuestsApplyProgressAction,
 } from '../actions'
 import { createBattleResultAction } from '../battle'
-
-function getFleetInfo(
-  deckShipId: number[],
-  state: RootState,
-): { shipname: string[]; shiptype: number[]; shipclass: number[] } {
-  const deckShipAPIShipId = deckShipId.map((id) => get(state, `info.ships.${id}.api_ship_id`, -1))
-  const shipname = deckShipAPIShipId
-    .map((id) => get(state, `const.$ships.${id}.api_name`, ''))
-    .filter((name: string) => name.length > 0)
-  const shiptype = deckShipAPIShipId
-    .map((id) => get(state, `const.$ships.${id}.api_stype`, -1))
-    .filter((id: number) => id > 0)
-  const shipclass = deckShipAPIShipId
-    .map((id) => get(state, `const.$ships.${id}.api_ctype`, -1))
-    .filter((id: number) => id > 0)
-  return { shipname, shiptype, shipclass }
-}
 
 export const questsCrossSliceMiddleware: Middleware = (store) => (next) => (action) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- RootState type from store

--- a/views/utils/selectors.ts
+++ b/views/utils/selectors.ts
@@ -112,6 +112,23 @@ function getMapHp(
   return [nowHp, maxCount, undefined]
 }
 
+export function getFleetInfo(
+  deckShipId: number[],
+  state: RootState,
+): { shipname: string[]; shiptype: number[]; shipclass: number[] } {
+  const deckShipAPIShipId = deckShipId.map((id) => get(state, `info.ships.${id}.api_ship_id`, -1))
+  const shipname = deckShipAPIShipId
+    .map((id) => get(state, `const.$ships.${id}.api_name`, ''))
+    .filter((name: string) => name.length > 0)
+  const shiptype = deckShipAPIShipId
+    .map((id) => get(state, `const.$ships.${id}.api_stype`, -1))
+    .filter((id: number) => id > 0)
+  const shipclass = deckShipAPIShipId
+    .map((id) => get(state, `const.$ships.${id}.api_ctype`, -1))
+    .filter((id: number) => id > 0)
+  return { shipname, shiptype, shipclass }
+}
+
 //### Selectors ###
 // Use it sparingly
 export const stateSelector = (state: RootState): RootState => state


### PR DESCRIPTION
For quests that we can test whether current fleet qualifies, add an extra item in quest counter like "✔ 1, 2" to indicate that 1st and 2nd fleet qualifies for that quest.

To minimize UI verbosity, this is only displayed when:

- the quest in question cares about fleet being used.
- at least one fleet qualifies.

Should work for both sortie and PvP quests, as impl makes no distinction:

AL作戦(クォータリー ):
<img width="469" height="299" alt="2026-06-03_23-43" src="https://github.com/user-attachments/assets/1d308b0c-1776-4d04-a3f8-6747a2ad3164" />

水上艦「艦隊防空演習」を実施せよ！(イヤーリー6月):
<img width="468" height="326" alt="2026-06-03_23-45" src="https://github.com/user-attachments/assets/6e30c5ae-a053-4ec1-8b5e-588bcf354799" />


