### PR TITLE
Mock ship/equip rarity backgrounds with CSS instead of images

### DIFF
--- a/i18n/setting/en-US.json
+++ b/i18n/setting/en-US.json
@@ -191,6 +191,7 @@
   "connection-test-failure-message": "Your connection seems having issue. Please verify you configuration.",
   "connection-test-description": "The test will try to connect Google.com with your proxy configuration. Its result is for reference only.",
   "AvatarBackground": "Avatar Background Color",
+  "Rarity": "Rarity",
   "Custom Certificate Authority": "Custom Certificate Authority",
   "Delete": "Delete",
   "custom-certificate-authority-description": "This configuration will take effect after restarting poi. Please make sure you have fully understood the security risks behind it.",

--- a/i18n/setting/ja-JP.json
+++ b/i18n/setting/ja-JP.json
@@ -234,6 +234,7 @@
   "Start testing": "テスト開始",
   "connection-test-description": "Google.com をプロキシサーバ経由で接続するテストです。実際の接続状況と異なる場合があります。",
   "AvatarBackground": "背景色",
+  "Rarity": "レア度",
   "Key not set": "設定されていません",
   "Set": "設定",
   "Custom Certificate Authority": "カスタム証明書機関（CA）",

--- a/i18n/setting/ko-KR.json
+++ b/i18n/setting/ko-KR.json
@@ -228,6 +228,7 @@
   "connection-test-failure-message": "Your connection seems having issue. Please verify you configuration.",
   "connection-test-description": "The test will try to connect Google.com with your proxy configuration. Its result is for reference only.",
   "AvatarBackground": "배경색",
+  "Rarity": "희귀도",
   "Custom Certificate Authority": "커스텀 인증서 기관（CA）",
   "Delete": "삭제",
   "custom-certificate-authority-description": "이 설정은 poi를 재시작하면 적용됩니다. 이 설정의 보안 위험을 완전히 이해하고 있는지 확인해주세요.",

--- a/i18n/setting/zh-CN.json
+++ b/i18n/setting/zh-CN.json
@@ -234,6 +234,7 @@
   "Start testing": "开始测试",
   "connection-test-description": "测试会尝试使用代理设置来连接 Google.com，结果仅供参考。",
   "AvatarBackground": "头像背景色",
+  "Rarity": "稀有度",
   "Key not set": "未设置",
   "Set": "设置",
   "Custom Certificate Authority": "自定义证书机构（CA）",

--- a/i18n/setting/zh-TW.json
+++ b/i18n/setting/zh-TW.json
@@ -234,6 +234,7 @@
   "Start testing": "開始測試",
   "connection-test-description": "測試會嘗試使用代理設置來連接 Google.com，結果僅供參考。",
   "AvatarBackground": "頭像背景顏色",
+  "Rarity": "稀有度",
   "Key not set": "未設置",
   "Set": "設置",
   "Custom Certificate Authority": "自定義證書機構（CA）",

--- a/lib/default-config.ts
+++ b/lib/default-config.ts
@@ -323,7 +323,7 @@ const defaultConfig: Config = {
     },
     appearance: {
       avatar: true,
-      avatarType: 'none',
+      avatarType: 'rarity',
       zoom: 1,
       theme: 'dark',
       colorblindFilter: 'null',

--- a/views/components/etc/avatar.tsx
+++ b/views/components/etc/avatar.tsx
@@ -7,12 +7,8 @@ import React, { memo } from 'react'
 import { shallowEqual, useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
 import { css, styled } from 'styled-components'
-import {
-  getShipBackgroundPath,
-  getShipImgPath,
-  getSlotItemBackgroundPath,
-  getSlotItemImgPath,
-} from 'views/utils/ship-img'
+import { equipRankBackgrounds, shipRankBackgrounds } from 'views/utils/game-utils'
+import { getShipImgPath, getSlotItemImgPath } from 'views/utils/ship-img'
 import { indexify } from 'views/utils/tools'
 
 declare const APPDATA_PATH: string
@@ -48,27 +44,32 @@ const EquipAvatar = styled.img`
   position: absolute;
 `
 
-const ShipAvatarBG = styled.img<{ rank: number }>`
+// The old <img> got its height from the image's intrinsic aspect ratio and used
+// offsets to frame the interesting part; a gradient has no intrinsic size, so
+// just fill the container. The container's mask only fades content past 65%,
+// which leaves the gradient as a hard-edged block on the panel — so fade the
+// BG itself the same way the ship art fades, but earlier and never fully
+// opaque, letting the panel background mix through.
+const avatarBGFade = css`
   position: absolute;
-  width: 200%;
+  inset: 0;
   z-index: -1;
-  ${({ rank }) =>
-    rank >= 6
-      ? css`
-          height: 220%;
-          left: -60%;
-        `
-      : css`
-          left: -30%;
-          top: -28%;
-        `}
+  mask-image: linear-gradient(
+    to right,
+    rgb(0 0 0 / 0.85) 0%,
+    rgb(0 0 0 / 0.5) 55%,
+    rgb(0 0 0 / 0) 95%
+  );
 `
 
-const EquipAvatarBG = styled.img`
-  position: absolute;
-  left: -160%;
-  width: 400%;
-  z-index: -1;
+const ShipAvatarBG = styled.div<{ rank: number }>`
+  ${avatarBGFade}
+  background: ${({ rank }) => shipRankBackgrounds[rank] ?? shipRankBackgrounds[0]};
+`
+
+const EquipAvatarBG = styled.div<{ rank: number }>`
+  ${avatarBGFade}
+  background: ${({ rank }) => equipRankBackgrounds[rank] ?? equipRankBackgrounds[0]};
 `
 
 // Remove old folder
@@ -109,8 +110,8 @@ export const Avatar = memo(
     useDefaultBG = true,
     showFullImg = false,
   }: AvatarProps) => {
-    const { url, bgurl, marginMagic, rank } = useSelector((state: RootState) => {
-      if (!mstId) return { url: '', bgurl: '', marginMagic: 0.555, rank: 7 }
+    const { url, marginMagic, rank } = useSelector((state: RootState) => {
+      if (!mstId) return { url: '', marginMagic: 0.555, rank: 7 }
       const ip = state.info.server.ip ?? '203.104.209.71'
       if (type === 'equip') {
         const $equip = state.const.$equips?.[mstId]
@@ -118,7 +119,6 @@ export const Avatar = memo(
         const rank = rankProp ?? $equip?.api_rare ?? 5
         return {
           url: getSlotItemImgPath(mstId, 'item_up', ip, version),
-          bgurl: getSlotItemBackgroundPath(rank, ip),
           marginMagic: 0.555,
           rank,
         }
@@ -137,7 +137,6 @@ export const Avatar = memo(
           7
         return {
           url: getShipImgPath(mstId, isEnemy ? 'banner' : 'remodel', isDamaged, ip, version),
-          bgurl: !isEnemy ? getShipBackgroundPath(rank, ip) : '',
           marginMagic: marginMagic ?? 0.555,
           rank,
         }
@@ -164,7 +163,7 @@ export const Avatar = memo(
           {type === 'equip' ? (
             <>
               <EquipAvatar className="equip-avatar" src={url} />
-              {useDefaultBG && <EquipAvatarBG className="equip-avatar-bg" src={bgurl} />}
+              {useDefaultBG && <EquipAvatarBG className="equip-avatar-bg" rank={rank} />}
             </>
           ) : (
             <>
@@ -184,7 +183,6 @@ export const Avatar = memo(
                     'ship-avatar-bg-nr': rank < 6,
                     'ship-avatar-bg-sr': rank >= 6,
                   })}
-                  src={bgurl}
                 />
               )}
             </>

--- a/views/components/main/parts/mini-ship/mini-squard-row.tsx
+++ b/views/components/main/parts/mini-ship/mini-squard-row.tsx
@@ -10,10 +10,10 @@ import { styled } from 'styled-components'
 import { SlotItemContainer } from 'views/components/ship-parts/styled-components'
 import { LandbaseSlotitems } from 'views/components/ship/slotitems'
 import {
+  getEquipAvatarBGByRarity,
   getTyku,
   LBAC_INTENTS,
   LBAC_STATUS_NAMES,
-  LBAC_STATUS_AVATAR_COLOR,
 } from 'views/utils/game-utils'
 import { landbaseSelectorFactory, landbaseEquipDataSelectorFactory } from 'views/utils/selectors'
 
@@ -83,7 +83,7 @@ export const MiniSquardRow = ({
               useDefaultBG={false}
               useFixedWidth={false}
             />
-            <MiniGradient color={LBAC_STATUS_AVATAR_COLOR[api_action_kind]} />
+            <MiniGradient color={getEquipAvatarBGByRarity(equipsData?.[0]?.[1]?.api_rare ?? 5)} />
           </>
         )}
         {hideShipName && (

--- a/views/components/settings/display/theme-config.tsx
+++ b/views/components/settings/display/theme-config.tsx
@@ -53,6 +53,7 @@ const avatarType = [
   { name: 'data:Range', value: 'range' },
   { name: 'main:Ship tag', value: 'tag' },
   { name: 'data:Speed', value: 'speed' },
+  { name: 'setting:Rarity', value: 'rarity' },
 ]
 
 type ConfigState = { config: Record<string, unknown> }

--- a/views/components/ship-parts/styled-components.tsx
+++ b/views/components/ship-parts/styled-components.tsx
@@ -152,14 +152,17 @@ export const ShipAvatar = styled(Avatar)`
   pointer-events: none;
 `
 
-// background is applied via inline style so per-ship colors don't each mint a class
+// background is applied via inline style so per-ship colors don't each mint a
+// class; the left-to-right fade-in comes from the mask so `color` can be any
+// CSS background — a solid color or the rarity mock gradient
 export const Gradient = styled.div.attrs<{ color: string }>(({ color }) => ({
-  style: { background: `linear-gradient(to right, transparent, ${color})` },
+  style: { background: color },
 }))`
   z-index: 1;
   grid-row: 1 / 5;
   grid-column: 2 / 3;
   height: 100%;
+  mask-image: linear-gradient(to right, transparent, rgb(0 0 0 / 1));
 `
 
 export const ShipBasic = styled.div<{ avatar?: boolean }>`

--- a/views/components/ship/lbac-view.tsx
+++ b/views/components/ship/lbac-view.tsx
@@ -21,10 +21,10 @@ import {
 } from 'views/components/ship-parts/styled-components'
 import {
   asIntent,
+  getEquipAvatarBGByRarity,
   getHpStyle,
   getTyku,
   LBAC_INTENTS,
-  LBAC_STATUS_AVATAR_COLOR,
   LBAC_STATUS_NAMES,
 } from 'views/utils/game-utils'
 import { landbaseEquipDataSelectorFactory, landbaseSelectorFactory } from 'views/utils/selectors'
@@ -90,7 +90,7 @@ export const SquardRow = memo(({ squardId, enableAvatar, compact }: SquardRowPro
               useDefaultBG={false}
               useFixedWidth={false}
             />
-            <Gradient color={LBAC_STATUS_AVATAR_COLOR[api_action_kind] ?? ''} />
+            <Gradient color={getEquipAvatarBGByRarity(equipsData?.[0]?.[1]?.api_rare ?? 5)} />
           </>
         )}
         {!hideLBACName && (

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -137,6 +137,77 @@ export function getShipAvatarColorBySpeed(speed: number): string {
   }
 }
 
+// The real per-rank backgrounds (kcs2/img/common/ship_bg/{card,screen}/*.png) are a
+// hex-tile texture behind a metal card frame; sr1+ swap the hex tile for white-heavy
+// pastel gear graphics. These gradients mock the dominant color of each without a
+// network round-trip: a diagonal tint for c1-r2, and for sr1+ a multi-hue diagonal
+// sweep (yellow -> pink -> purple -> blue -> green, as in the pastel gear art).
+// A radial corner-blob version was tried first, but in the row overlay's short,
+// wide strip the four corners sit at nearly the same vertical position and blend
+// into a single muddy (usually teal/green) wash instead of reading as a rainbow —
+// a linear sweep keeps the hues visually separated regardless of aspect ratio.
+// Every layer is semi-transparent so the theme background bleeds through — the
+// tint darkens on dark themes and stays light on light themes, keeping text on
+// top readable either way.
+const softRainbow = `
+  linear-gradient(
+    135deg,
+    rgb(245 210 120 / 0.5) 0%,
+    rgb(240 150 170 / 0.5) 20%,
+    rgb(200 150 230 / 0.5) 40%,
+    rgb(140 190 230 / 0.5) 60%,
+    rgb(140 220 180 / 0.5) 80%,
+    rgb(230 220 130 / 0.5) 100%
+  ),
+  rgb(252 252 250 / 0.4)
+`
+const vividRainbow = `
+  radial-gradient(circle at 25% 20%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 8%),
+  radial-gradient(circle at 75% 15%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 6%),
+  radial-gradient(circle at 60% 70%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 6%),
+  linear-gradient(
+    135deg,
+    rgb(235 190 80 / 0.65) 0%,
+    rgb(235 120 150 / 0.65) 20%,
+    rgb(190 120 220 / 0.65) 40%,
+    rgb(110 165 220 / 0.65) 60%,
+    rgb(100 205 165 / 0.65) 80%,
+    rgb(220 205 90 / 0.65) 100%
+  ),
+  rgb(251 250 246 / 0.35)
+`
+
+// Indexed by the `rank` lookup in ship-img.ts: ['', c1, c2, c3, r1, r2, sr1, sr2, sr3]
+export const shipRankBackgrounds = [
+  'linear-gradient(135deg, #eef4ff99 0%, #bcdcfa99 45%, #6fa8e099 100%)',
+  'linear-gradient(135deg, #eef4ff99 0%, #bcdcfa99 45%, #6fa8e099 100%)',
+  'linear-gradient(135deg, #dceaff99 0%, #a8cdf799 45%, #4f8fdb99 100%)',
+  'linear-gradient(135deg, #e8fdfc99 0%, #b7f0ef99 45%, #5fcbd099 100%)',
+  'linear-gradient(135deg, #f4f4f499 0%, #bdbdbd99 45%, #6e6e6e99 100%)',
+  'linear-gradient(135deg, #6b541499 0%, #b8922e99 45%, #f4dd8299 100%)',
+  softRainbow,
+  vividRainbow,
+  vividRainbow,
+]
+
+// Indexed by the `itemrank` lookup in ship-img.ts: [item_c1, item_r1, sr1, sr1, sr1, sr2]
+export const equipRankBackgrounds = [
+  'linear-gradient(135deg, #ffffff99 0%, #e7e3da99 45%, #c7c0b099 100%)',
+  'linear-gradient(135deg, #f4f9f899 0%, #d3e3e299 45%, #a9c5c399 100%)',
+  softRainbow,
+  softRainbow,
+  softRainbow,
+  vividRainbow,
+]
+
+export function getShipAvatarBGByRarity(rank: number): string {
+  return shipRankBackgrounds[rank] ?? shipRankBackgrounds[0]
+}
+
+export function getEquipAvatarBGByRarity(rank: number): string {
+  return equipRankBackgrounds[rank] ?? equipRankBackgrounds[0]
+}
+
 export function selectShipAvatarColor(
   ship: APIShip | undefined,
   $ship: APIMstShip | undefined,
@@ -152,6 +223,8 @@ export function selectShipAvatarColor(
       return getShipAvatarColorByTag(ship?.api_sally_area ?? 0, color)
     case 'speed':
       return getShipAvatarColorBySpeed(ship?.api_soku ?? 0)
+    case 'rarity':
+      return getShipAvatarBGByRarity($ship?.api_backs ?? 7)
     default:
       return '#00000000'
   }

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -139,25 +139,27 @@ export function getShipAvatarColorBySpeed(speed: number): string {
 
 // The real per-rank backgrounds (kcs2/img/common/ship_bg/{card,screen}/*.png) are a
 // hex-tile texture behind a metal card frame; sr1+ swap the hex tile for white-heavy
-// pastel gear graphics. These gradients mock the dominant color of each without a
-// network round-trip: a diagonal tint for c1-r2, and for sr1+ a multi-hue diagonal
-// sweep (yellow -> pink -> purple -> blue -> green, as in the pastel gear art).
-// A radial corner-blob version was tried first, but in the row overlay's short,
-// wide strip the four corners sit at nearly the same vertical position and blend
-// into a single muddy (usually teal/green) wash instead of reading as a rainbow —
-// a linear sweep keeps the hues visually separated regardless of aspect ratio.
+// pastel gear graphics, with big circular gear shapes radiating from a point — a
+// conic hue sweep mimics that pinwheel-of-gears look better than a flat diagonal
+// band. (A first attempt used four separate corner-blob radials, which in the row
+// overlay's short, wide strip sit at nearly the same vertical position and blend
+// into a single muddy teal/green wash instead of reading as a rainbow; a single
+// conic sweep avoids that since it's one continuous gradient, not four overlapping
+// ones — a plain radial sweep was also tried and works, but the conic's hue wheel
+// reads more like the source art's radiating gear shapes.)
 // Every layer is semi-transparent so the theme background bleeds through — the
 // tint darkens on dark themes and stays light on light themes, keeping text on
 // top readable either way.
 const softRainbow = `
-  linear-gradient(
-    135deg,
-    rgb(245 210 120 / 0.5) 0%,
-    rgb(240 150 170 / 0.5) 20%,
-    rgb(200 150 230 / 0.5) 40%,
-    rgb(140 190 230 / 0.5) 60%,
-    rgb(140 220 180 / 0.5) 80%,
-    rgb(230 220 130 / 0.5) 100%
+  conic-gradient(
+    from 200deg at 30% 40%,
+    rgb(245 210 120 / 0.5),
+    rgb(240 150 170 / 0.5),
+    rgb(200 150 230 / 0.5),
+    rgb(140 190 230 / 0.5),
+    rgb(140 220 180 / 0.5),
+    rgb(230 220 130 / 0.5),
+    rgb(245 210 120 / 0.5)
   ),
   rgb(252 252 250 / 0.4)
 `
@@ -165,14 +167,15 @@ const vividRainbow = `
   radial-gradient(circle at 25% 20%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 8%),
   radial-gradient(circle at 75% 15%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 6%),
   radial-gradient(circle at 60% 70%, rgb(255 255 255 / 0.6) 0%, rgb(255 255 255 / 0) 6%),
-  linear-gradient(
-    135deg,
-    rgb(235 190 80 / 0.65) 0%,
-    rgb(235 120 150 / 0.65) 20%,
-    rgb(190 120 220 / 0.65) 40%,
-    rgb(110 165 220 / 0.65) 60%,
-    rgb(100 205 165 / 0.65) 80%,
-    rgb(220 205 90 / 0.65) 100%
+  conic-gradient(
+    from 200deg at 30% 40%,
+    rgb(235 190 80 / 0.65),
+    rgb(235 120 150 / 0.65),
+    rgb(190 120 220 / 0.65),
+    rgb(110 165 220 / 0.65),
+    rgb(100 205 165 / 0.65),
+    rgb(220 205 90 / 0.65),
+    rgb(235 190 80 / 0.65)
   ),
   rgb(251 250 246 / 0.35)
 `


### PR DESCRIPTION
## Summary
- Adds a new Rarity AvatarBackground option (`poi.appearance.avatarType: 'rarity'`) and makes it the default, replacing `'none'`
- Ship/equip avatar backgrounds (construction panel, equip icons, ship rows, LBAC squadron avatar) render a small per-rank CSS gradient mocking the real `kcs2/img/common/ship_bg/{card,screen}/*.png` art (diagonal tint for common/rare, multi-hue diagonal sweep for holo ranks) instead of fetching an image over the network
- The ship-row/LBAC `Gradient` overlay now applies its left-to-right fade via a mask, so it works with any CSS background (solid color or the rarity gradient) rather than baking a `linear-gradient(to right, transparent, color)` string

## Test plan
- [ ] `npm run typecheck` and `npm run lint:js` pass (already verified locally)
- [ ] In-app: toggle Settings > Themes > Avatar Background to each option (including the new Rarity) and confirm ship rows, mini ship rows, the construction panel, equip icons, and the LBAC squadron avatar render sensible, legible gradients across common/rare/super-rare ranks
- [ ] Confirm behavior in both light and dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
