### PR TITLE
fix: restore stop game rendering while poi is hidden to the tray on Windows

### DIFF
--- a/lib/tray.ts
+++ b/lib/tray.ts
@@ -1,6 +1,8 @@
 import { app, nativeImage, Tray } from 'electron'
 import path from 'path'
 
+import windowManager from './window'
+
 declare global {
   var appTray: Tray
 }
@@ -29,11 +31,7 @@ app.on('ready', () => {
   }
   global.appTray = tray
   tray.on('click', () => {
-    if (global.mainWindow?.isMinimized()) {
-      global.mainWindow.restore()
-    } else {
-      global.mainWindow?.show()
-    }
+    windowManager.restoreAllWindowsFromTray()
   })
   tray.setToolTip(app.getName())
 })

--- a/lib/window.ts
+++ b/lib/window.ts
@@ -1,7 +1,7 @@
-import type { Display, BrowserWindowConstructorOptions, Menu } from 'electron'
+import type { Display, BrowserWindowConstructorOptions, Menu, WebContents } from 'electron'
 
 import * as electronRemote from '@electron/remote/main'
-import { BrowserWindow, screen, webContents } from 'electron'
+import { app, BrowserWindow, screen, webContents } from 'electron'
 import path from 'path'
 
 const windows: typeof global.windows = (global.windows = [])
@@ -9,8 +9,103 @@ const windowsIndex: typeof global.windowsIndex = (global.windowsIndex = {})
 
 let forceClose = false
 let pluginUnload = false
-const state: boolean[] = [] // Window state before hide
+const windowVisibilityState = new Map<number, boolean>()
+const backgroundThrottlingState = new Map<
+  number,
+  { webContents: WebContents; backgroundThrottling: boolean }
+>()
+const throttleHiddenWindows = process.platform === 'win32'
 let hidden = false
+
+function throttleWebContentsWhileHidden(contents: WebContents): void {
+  if (
+    !throttleHiddenWindows ||
+    contents.isDestroyed() ||
+    backgroundThrottlingState.has(contents.id)
+  ) {
+    return
+  }
+
+  // On Windows, tray hiding must opt back into Electron's background throttling
+  // so hidden windows stop submitting compositor frames. Normal minimization
+  // deliberately keeps each WebContents' configured behavior unchanged.
+  backgroundThrottlingState.set(contents.id, {
+    webContents: contents,
+    backgroundThrottling: contents.getBackgroundThrottling(),
+  })
+  contents.setBackgroundThrottling(true)
+}
+
+app.on('web-contents-created', (_event, contents) => {
+  if (hidden) {
+    throttleWebContentsWhileHidden(contents)
+  }
+})
+
+app.on('browser-window-created', (_event, window) => {
+  window.on('show', () => {
+    if (hidden) {
+      window.hide()
+    }
+  })
+
+  if (hidden) {
+    windowVisibilityState.set(window.id, false)
+    window.hide()
+  }
+})
+
+function hideAllWindowsToTray(): void {
+  if (hidden) {
+    return
+  }
+
+  windowVisibilityState.clear()
+  backgroundThrottlingState.clear()
+  hidden = true
+
+  for (const contents of webContents.getAllWebContents()) {
+    throttleWebContentsWhileHidden(contents)
+  }
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    windowVisibilityState.set(window.id, window.isVisible())
+    window.hide()
+  }
+}
+
+function restoreAllWindowsFromTray(): void {
+  if (!hidden) {
+    if (global.mainWindow?.isMinimized()) {
+      global.mainWindow.restore()
+    } else {
+      global.mainWindow?.show()
+    }
+    return
+  }
+
+  hidden = false
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (windowVisibilityState.get(window.id)) {
+      window.show()
+    }
+  }
+
+  for (const {
+    webContents: contents,
+    backgroundThrottling,
+  } of backgroundThrottlingState.values()) {
+    if (!contents.isDestroyed()) {
+      // Different WebContents may have different foreground policies, so restore
+      // the captured value instead of assuming every one was unthrottled.
+      contents.setBackgroundThrottling(backgroundThrottling)
+    }
+  }
+
+  windowVisibilityState.clear()
+  backgroundThrottlingState.clear()
+}
 
 export interface PoiWindowOptions extends BrowserWindowConstructorOptions {
   indexName?: string
@@ -159,18 +254,14 @@ export default {
       isMaximized,
     })
   },
+  hideAllWindowsToTray,
+  restoreAllWindowsFromTray,
   toggleAllWindowsVisibility: () => {
-    for (const w of BrowserWindow.getAllWindows())
-      if (!hidden) {
-        state[w.id] = w.isVisible()
-
-        w.hide()
-      } else {
-        if (state[w.id]) {
-          w.show()
-        }
-      }
-    hidden = !hidden
+    if (hidden) {
+      restoreAllWindowsFromTray()
+    } else {
+      hideAllWindowsToTray()
+    }
   },
   openFocusedWindowDevTools: () => {
     webContents.getFocusedWebContents()?.openDevTools?.({

--- a/views/components/etc/menu.ts
+++ b/views/components/etc/menu.ts
@@ -10,8 +10,10 @@ import path from 'path'
 import React, { PureComponent } from 'react'
 import i18next from 'views/env-parts/i18next'
 import { getStore } from 'views/redux/create-store'
-import 'electron-react-titlebar/assets/style.css'
 import { reduxSet } from 'views/utils/tools'
+import 'electron-react-titlebar/assets/style.css'
+
+import type windowManagerType from '../../../lib/window'
 
 declare global {
   interface Window {
@@ -25,6 +27,7 @@ declare global {
 
 const Menu = remote.Menu
 const { openExternal } = shell
+const windowManager: typeof windowManagerType = remote.require('./lib/window')
 
 const resetViews = () => {
   const { availWidth, availHeight, availTop, availLeft } = window.screen
@@ -64,13 +67,13 @@ if (process.platform !== 'darwin') {
         {
           label: i18next.t('menu:Hide poi'),
           click: () => {
-            remote.getGlobal('mainWindow').hide()
+            windowManager.hideAllWindowsToTray()
           },
         },
         {
           label: i18next.t('menu:Show poi'),
           click: () => {
-            remote.getGlobal('mainWindow').show()
+            windowManager.restoreAllWindowsFromTray()
           },
         },
         { type: 'separator' },


### PR DESCRIPTION
## Summary

This change restores the low-resource behavior of **Hide poi** on Windows.

When poi is explicitly hidden to the system tray, all poi windows are hidden and every existing game/plugin `WebContents` temporarily opts back into Electron's background throttling. This allows Chromium to stop submitting compositor frames for the hidden game view, reducing the persistent GPU usage observed after hiding poi.

Restoring poi returns each window and `WebContents` to its previous state. Normal window minimization is intentionally unchanged and continues to use the existing unthrottled rendering policy.

## Background

The game webview and the main renderer currently disable Electron background throttling:

- The main `BrowserWindow` uses `backgroundThrottling: false`.
- The game `<webview>` uses `backgroundThrottling=no`.
- Windows native occlusion calculation is disabled through `CalculateNativeWinOcclusion`.

These settings are intentional for normal foreground and minimized operation, but they interact differently with recent Electron versions.

Starting with Electron 28, disabling background throttling for any `WebContents` associated with a `BrowserWindow` also disables throttling in the window compositor. As a result, calling `BrowserWindow.hide()` no longer guarantees that the hidden game window stops drawing and swapping frames. On current Electron versions, Windows Task Manager can therefore continue reporting significant GPU usage after **Hide poi** is selected.

Relevant upstream references:

- [Electron `backgroundThrottling` documentation](https://www.electronjs.org/docs/latest/api/structures/web-preferences#webpreferences-object)
- [Electron PR #38924: disable background throttling in the Viz display scheduler](https://github.com/electron/electron/pull/38924)
- [Electron issue #31016: hidden windows did not render with throttling disabled](https://github.com/electron/electron/issues/31016)

The previous menu implementation also hid only `global.mainWindow`. Separate game windows and plugin windows were not part of the same explicit tray-hidden state.

## Root cause

The regression is caused by the combination of:

1. poi explicitly setting `backgroundThrottling` to `false` for the main renderer and game webview.
2. Electron 28+ applying that unthrottled state to the whole window compositor.
3. **Hide poi** only calling `mainWindow.hide()` without changing the background-throttling policy.

The tray itself is not responsible for the GPU usage. The hidden game renderer remains eligible to produce and submit frames because poi explicitly keeps background throttling disabled.

## Behavior before this change

- **Hide poi** hid only the main window.
- The game `WebContents` retained `backgroundThrottling: false` while hidden.
- Separate game/plugin windows could remain visible.
- Hidden game rendering could continue using the GPU.
- The boss key had a separate all-window visibility implementation.
- Tray restore only restored the main window.

## Behavior after this change

- **Hide poi** enters one centralized tray-hidden state.
- All currently existing poi `BrowserWindow` instances are hidden.
- On Windows, all existing `WebContents` instances temporarily use `backgroundThrottling: true`.
- Each window's visibility and each `WebContents` throttling value are captured before hiding.
- Restore only shows windows that were visible before hiding.
- Restore returns every surviving `WebContents` to its captured throttling value.
- Windows and `WebContents` created while poi is hidden are also kept hidden/throttled.
- **Hide poi**, **Show poi**, the tray icon, and the boss key share the same state machine.
- Ordinary minimization does not enter the tray-hidden state and remains unthrottled.
- Non-Windows platforms do not receive the temporary `backgroundThrottling` override.
