### PR TITLE
feat: set up Google Analytics 4 via the Measurement Protocol

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra'
 import { memoize } from 'lodash'
 import path from 'path'
 
+import type * as analyticsType from './lib/analytics'
 // eslint-disable-next-line import-x/no-rename-default
 import type configType from './lib/config'
 import type * as kcsResourceType from './lib/kcs-resource'
@@ -119,6 +120,10 @@ if (dbg.isEnabled()) {
       paths: [ROOT, APPDATA_PATH],
     })
   }
+  // Not gated on poi.misc.analytics here: lib/analytics checks the config on every
+  // send, so toggling the setting off takes effect without a restart.
+  const analytics: typeof analyticsType = require('./lib/analytics')
+  analytics.init()
 }
 
 let mainWindow: BrowserWindow | null = null

--- a/lib/__tests__/analytics.spec.ts
+++ b/lib/__tests__/analytics.spec.ts
@@ -1,0 +1,153 @@
+jest.mock('../env.ts', () => ({ POI_VERSION: '11.1.0' }))
+jest.mock('../debug.ts', () => ({ log: jest.fn(), isEnabled: () => false }))
+
+const mockConfigStore = new Map<string, unknown>()
+jest.mock('../config.ts', () => ({
+  get: (path: string, fallback?: unknown) =>
+    mockConfigStore.has(path) ? mockConfigStore.get(path) : fallback,
+  set: (path: string, value: unknown) => mockConfigStore.set(path, value),
+}))
+
+import type * as analyticsModule from '../analytics'
+
+type Analytics = typeof analyticsModule
+
+interface CollectedEvent {
+  name: string
+  params: Record<string, unknown>
+}
+
+interface CollectedPayload {
+  client_id: string
+  user_id?: string
+  events: CollectedEvent[]
+}
+
+const loadAnalytics = (): Analytics => {
+  let mod: Analytics | undefined
+  jest.isolateModules(() => {
+    mod = require('../analytics')
+  })
+  if (!mod) {
+    throw new Error('analytics module failed to load')
+  }
+  return mod
+}
+
+/** The request body of the nth /mp/collect call. */
+const payloadOf = (call: number): CollectedPayload =>
+  JSON.parse(String(jest.mocked(global.fetch).mock.calls[call][1]?.body))
+
+const urlOf = (call: number): string => String(jest.mocked(global.fetch).mock.calls[call][0])
+
+describe('analytics (GA4 measurement protocol)', () => {
+  beforeEach(() => {
+    mockConfigStore.clear()
+    process.env.POI_GA_MEASUREMENT_ID = 'G-TESTID0000'
+    process.env.POI_GA_API_SECRET = 'test-secret'
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 204 })
+  })
+
+  afterEach(() => {
+    delete process.env.POI_GA_MEASUREMENT_ID
+    delete process.env.POI_GA_API_SECRET
+  })
+
+  it('sends nothing when credentials are absent', () => {
+    delete process.env.POI_GA_MEASUREMENT_ID
+    delete process.env.POI_GA_API_SECRET
+    const analytics = loadAnalytics()
+    analytics.init()
+    analytics.sendEvent('heartbeat')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('sends nothing when the user opted out', () => {
+    mockConfigStore.set('poi.misc.analytics', false)
+    const analytics = loadAnalytics()
+    analytics.init()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('respects an opt-out made after startup, without a restart', () => {
+    const analytics = loadAnalytics()
+    analytics.init()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    mockConfigStore.set('poi.misc.analytics', false)
+    analytics.sendEvent('heartbeat')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('posts app_start with credentials in the query string', () => {
+    const analytics = loadAnalytics()
+    analytics.init()
+
+    expect(urlOf(0)).toBe(
+      'https://www.google-analytics.com/mp/collect?measurement_id=G-TESTID0000&api_secret=test-secret',
+    )
+    const payload = payloadOf(0)
+    expect(payload.events[0].name).toBe('app_start')
+    expect(payload.events[0].params).toMatchObject({
+      poi_version: '11.1.0',
+      platform: process.platform,
+      arch: process.arch,
+    })
+    // Without these two GA4 drops the event from most reports.
+    expect(payload.events[0].params.session_id).toEqual(expect.any(String))
+    expect(payload.events[0].params.engagement_time_msec).toBe(1)
+  })
+
+  it('generates a client id once and persists it across launches', () => {
+    loadAnalytics().init()
+    const first = payloadOf(0).client_id
+    expect(first).toEqual(expect.any(String))
+    expect(mockConfigStore.get('poi.misc.analyticsClientId')).toBe(first)
+
+    jest.mocked(global.fetch).mockClear()
+    loadAnalytics().init()
+    expect(payloadOf(0).client_id).toBe(first)
+  })
+
+  it('attaches the member id as user_id and emits a versioned page_view', () => {
+    const analytics = loadAnalytics()
+    analytics.setUserId('12345')
+
+    const payload = payloadOf(0)
+    expect(payload.user_id).toBe('12345')
+    expect(payload.events[0].name).toBe('page_view')
+    expect(payload.events[0].params.page_location).toBe('https://analytics.poooi.app/11.1.0/')
+    analytics.stopHeartbeat()
+  })
+
+  it('ignores a repeated member id so page_view is not double counted', () => {
+    const analytics = loadAnalytics()
+    analytics.setUserId('12345')
+    analytics.setUserId('12345')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    analytics.stopHeartbeat()
+  })
+
+  it('sends a heartbeat on an interval once the member id is known', () => {
+    jest.useFakeTimers()
+    const analytics = loadAnalytics()
+    analytics.setUserId('12345')
+    jest.mocked(global.fetch).mockClear()
+
+    jest.advanceTimersByTime(240000 * 2)
+    const names = jest
+      .mocked(global.fetch)
+      .mock.calls.map((_call, i) => payloadOf(i).events[0].name)
+    expect(names).toEqual(['heartbeat', 'heartbeat'])
+
+    analytics.stopHeartbeat()
+    jest.useRealTimers()
+  })
+
+  it('swallows network failures', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ENOTFOUND'))
+    const analytics = loadAnalytics()
+    expect(() => analytics.init()).not.toThrow()
+    await Promise.resolve()
+  })
+})

--- a/lib/__tests__/analytics.spec.ts
+++ b/lib/__tests__/analytics.spec.ts
@@ -53,13 +53,23 @@ describe('analytics (GA4 measurement protocol)', () => {
     delete process.env.POI_GA_API_SECRET
   })
 
-  it('sends nothing when credentials are absent', () => {
-    delete process.env.POI_GA_MEASUREMENT_ID
-    delete process.env.POI_GA_API_SECRET
+  it('sends nothing when credentials are blanked out', () => {
+    // A set-but-empty env var blanks the built-in credential; this is the escape
+    // hatch a fork or a local build uses to stay off poi's GA property.
+    process.env.POI_GA_MEASUREMENT_ID = ''
+    process.env.POI_GA_API_SECRET = ''
     const analytics = loadAnalytics()
     analytics.init()
     analytics.sendEvent('heartbeat')
     expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the built-in credentials when no env override is set', () => {
+    delete process.env.POI_GA_MEASUREMENT_ID
+    delete process.env.POI_GA_API_SECRET
+    const analytics = loadAnalytics()
+    analytics.init()
+    expect(urlOf(0)).toMatch(/measurement_id=G-[A-Z0-9]+&api_secret=.+$/)
   })
 
   it('sends nothing when the user opted out', () => {
@@ -141,6 +151,19 @@ describe('analytics (GA4 measurement protocol)', () => {
     expect(names).toEqual(['heartbeat', 'heartbeat'])
 
     analytics.stopHeartbeat()
+    jest.useRealTimers()
+  })
+
+  it('stops the heartbeat when the member id is cleared', () => {
+    jest.useFakeTimers()
+    const analytics = loadAnalytics()
+    analytics.setUserId('12345')
+    analytics.setUserId(undefined)
+    jest.mocked(global.fetch).mockClear()
+
+    // Otherwise the heartbeat keeps firing with no user_id attached.
+    jest.advanceTimersByTime(240000 * 2)
+    expect(global.fetch).not.toHaveBeenCalled()
     jest.useRealTimers()
   })
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -16,10 +16,9 @@ import config from './config'
 import dbg from './debug'
 import { POI_VERSION } from './env'
 
-// FIXME: fill in the credentials of the poi GA4 property.
-// Create them at GA4 Admin -> Data Streams -> (stream) -> Measurement Protocol API secrets.
+// Credentials of the poi GA4 property, from
+// GA4 Admin -> Data Streams -> (stream) -> Measurement Protocol API secrets.
 // Both may be overridden at runtime by POI_GA_MEASUREMENT_ID / POI_GA_API_SECRET.
-// Analytics stays inert while either is blank.
 const MEASUREMENT_ID = 'G-9HGBLSG9YF'
 const API_SECRET = 'Ccwwv21XRT-iwjC6hdFLlQ'
 
@@ -32,8 +31,14 @@ const SYNTHETIC_ORIGIN = 'https://analytics.poooi.app'
 
 const HEARTBEAT_INTERVAL = 240000
 
-const measurementId = process.env.POI_GA_MEASUREMENT_ID || MEASUREMENT_ID
-const apiSecret = process.env.POI_GA_API_SECRET || API_SECRET
+// An env var that is set but empty blanks the built-in credential rather than
+// falling back to it, which is how a fork or a local build opts out of reporting
+// to poi's property. Analytics stays inert while either credential is blank.
+const resolveCredential = (override: string | undefined, fallback: string): string =>
+  override === undefined ? fallback : override
+
+const measurementId = resolveCredential(process.env.POI_GA_MEASUREMENT_ID, MEASUREMENT_ID)
+const apiSecret = resolveCredential(process.env.POI_GA_API_SECRET, API_SECRET)
 
 // GA4 groups events into a session by `session_id`; one poi launch is one session.
 const sessionId = String(Date.now())
@@ -117,6 +122,13 @@ export const sendEvent = (name: string, params: EventParams = {}): void => {
     })
 }
 
+export const stopHeartbeat = (): void => {
+  if (heartbeat) {
+    clearInterval(heartbeat)
+    heartbeat = undefined
+  }
+}
+
 /**
  * Associate subsequent events with the admiral's member id, mirroring the old
  * `ga('set', 'userId', ...)` call. Sending a page view here is what marks the
@@ -129,6 +141,9 @@ export const setUserId = (id: string | number | undefined): void => {
   }
   userId = next
   if (!userId) {
+    // Otherwise the heartbeat keeps firing without a user_id attached, filling
+    // GA4 with unattributed events.
+    stopHeartbeat()
     return
   }
 
@@ -144,16 +159,12 @@ export const setUserId = (id: string | number | undefined): void => {
   }
 }
 
-export const stopHeartbeat = (): void => {
-  if (heartbeat) {
-    clearInterval(heartbeat)
-    heartbeat = undefined
-  }
-}
-
 export const init = (): void => {
-  if (!measurementId || !apiSecret) {
-    dbg.log('analytics: no GA4 credentials configured, analytics disabled')
+  // Deliberately the same gate as every other send: isEnabled() covers both the
+  // credentials and the user's consent, so there is only one expression to keep
+  // correct as this evolves.
+  if (!isEnabled()) {
+    dbg.log('analytics: GA4 disabled (no credentials, or the user opted out)')
     return
   }
   sendEvent('app_start')

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,160 @@
+// Google Analytics 4, via the Measurement Protocol.
+//
+// poi previously used Universal Analytics (analytics.js) loaded in the renderer
+// from index.html. UA was sunset, and loading gtag.js in a file:// renderer needs
+// both a CSP allowance for googletagmanager.com and a cookie-origin override hack.
+// Instead we talk to the Measurement Protocol directly from the main process:
+// no third-party script, no cookies, and it keeps working behind the game proxy
+// (`*.google-analytics.com` is already in the proxy BYPASS_RULES, see lib/proxy.ts).
+//
+// Caveat inherited from the Measurement Protocol: GA does not synthesise sessions
+// or page views for us, so `session_id` and `engagement_time_msec` are attached to
+// every event by hand -- without them events are dropped from most GA4 reports.
+import { randomUUID } from 'crypto'
+
+import config from './config'
+import dbg from './debug'
+import { POI_VERSION } from './env'
+
+// FIXME: fill in the credentials of the poi GA4 property.
+// Create them at GA4 Admin -> Data Streams -> (stream) -> Measurement Protocol API secrets.
+// Both may be overridden at runtime by POI_GA_MEASUREMENT_ID / POI_GA_API_SECRET.
+// Analytics stays inert while either is blank.
+const MEASUREMENT_ID = 'G-9HGBLSG9YF'
+const API_SECRET = 'Ccwwv21XRT-iwjC6hdFLlQ'
+
+const ENDPOINT = 'https://www.google-analytics.com/mp/collect'
+
+// Kept from the UA setup: poi has no real URLs, so page views are reported against
+// a synthetic host keyed by version. This is what made the version breakdown legible
+// in the old property, so it is worth preserving.
+const SYNTHETIC_ORIGIN = 'https://analytics.poooi.app'
+
+const HEARTBEAT_INTERVAL = 240000
+
+const measurementId = process.env.POI_GA_MEASUREMENT_ID || MEASUREMENT_ID
+const apiSecret = process.env.POI_GA_API_SECRET || API_SECRET
+
+// GA4 groups events into a session by `session_id`; one poi launch is one session.
+const sessionId = String(Date.now())
+
+let clientId: string | undefined
+let userId: string | undefined
+let heartbeat: NodeJS.Timeout | undefined
+
+interface EventParams {
+  [key: string]: string | number | undefined
+}
+
+/**
+ * The GA4 client id identifies an install, not a person. It is generated locally
+ * and persisted so returning-user metrics work across launches.
+ */
+const getClientId = (): string => {
+  if (clientId) {
+    return clientId
+  }
+  const stored = config.get('poi.misc.analyticsClientId')
+  if (typeof stored === 'string' && stored) {
+    clientId = stored
+  } else {
+    clientId = randomUUID()
+    config.set('poi.misc.analyticsClientId', clientId)
+  }
+  return clientId
+}
+
+const isEnabled = (): boolean =>
+  Boolean(measurementId) && Boolean(apiSecret) && config.get('poi.misc.analytics', true)
+
+/**
+ * Fire-and-forget a single event. Never throws and never rejects: analytics must
+ * not be able to take poi down, and a user with no network is not an error.
+ */
+export const sendEvent = (name: string, params: EventParams = {}): void => {
+  if (!isEnabled()) {
+    return
+  }
+
+  const payload = {
+    client_id: getClientId(),
+    ...(userId ? { user_id: userId } : {}),
+    events: [
+      {
+        name,
+        params: {
+          session_id: sessionId,
+          // GA4 discards events with no engagement time; the exact value only
+          // affects the "engaged sessions" metric, so report a nominal 1ms.
+          engagement_time_msec: 1,
+          poi_version: POI_VERSION,
+          platform: process.platform,
+          arch: process.arch,
+          ...params,
+        },
+      },
+    ],
+  }
+
+  const url = `${ENDPOINT}?measurement_id=${encodeURIComponent(
+    measurementId,
+  )}&api_secret=${encodeURIComponent(apiSecret)}`
+
+  void fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+    .then((res) => {
+      // The collect endpoint answers 204 with an empty body and does not validate
+      // the payload. Use /debug/mp/collect by hand when an event fails to show up.
+      if (!res.ok) {
+        dbg.log(`analytics: ${name} rejected with ${res.status}`)
+      }
+    })
+    .catch((e) => {
+      dbg.log(`analytics: ${name} failed`, e)
+    })
+}
+
+/**
+ * Associate subsequent events with the admiral's member id, mirroring the old
+ * `ga('set', 'userId', ...)` call. Sending a page view here is what marks the
+ * transition from "poi launched" to "poi in use".
+ */
+export const setUserId = (id: string | number | undefined): void => {
+  const next = id === undefined || id === null || id === '' ? undefined : String(id)
+  if (next === userId) {
+    return
+  }
+  userId = next
+  if (!userId) {
+    return
+  }
+
+  sendEvent('page_view', {
+    page_location: `${SYNTHETIC_ORIGIN}/${POI_VERSION}/`,
+    page_title: `poi ${POI_VERSION}`,
+  })
+
+  if (!heartbeat) {
+    heartbeat = setInterval(() => sendEvent('heartbeat'), HEARTBEAT_INTERVAL)
+    // Do not let the heartbeat keep the process alive on quit.
+    heartbeat.unref?.()
+  }
+}
+
+export const stopHeartbeat = (): void => {
+  if (heartbeat) {
+    clearInterval(heartbeat)
+    heartbeat = undefined
+  }
+}
+
+export const init = (): void => {
+  if (!measurementId || !apiSecret) {
+    dbg.log('analytics: no GA4 credentials configured, analytics disabled')
+    return
+  }
+  sendEvent('app_start')
+}

--- a/lib/default-config.ts
+++ b/lib/default-config.ts
@@ -29,6 +29,8 @@ interface PoiMisc {
   homepage: string
   networklog: boolean
   analytics: boolean
+  /** Locally generated GA4 client id. Identifies an install, not a person. */
+  analyticsClientId?: string
   exceptionReporting: boolean
   async: boolean
   screenshot: Screenshot

--- a/views/components/settings/main/advanced-config/index.tsx
+++ b/views/components/settings/main/advanced-config/index.tsx
@@ -47,6 +47,11 @@ const SWITCHES = [
     defaultValue: false,
   },
   {
+    label: 'Send data to Google Analytics',
+    configName: 'poi.misc.analytics',
+    defaultValue: true,
+  },
+  {
     label: 'Send program exceptions to poi team',
     configName: 'poi.misc.exceptionReporting',
     defaultValue: true,

--- a/views/services.ts
+++ b/views/services.ts
@@ -12,6 +12,7 @@ import { log, error } from 'views/services/alert'
 import { isInGame } from 'views/utils/game-utils'
 
 const gameAPIBroadcaster: GameAPIBroadcaster = remote.require('./lib/game-api-broadcaster')
+import './services/google-analytics'
 import './services/update'
 import './services/layout'
 import './services/welcome'

--- a/views/services/google-analytics.ts
+++ b/views/services/google-analytics.ts
@@ -1,0 +1,28 @@
+// Renderer half of the GA4 integration: the admiral's member id only exists in the
+// renderer store, so we watch it here and hand it to the main-process collector.
+// All transport lives in lib/analytics.ts.
+import type * as analyticsType from 'lib/analytics'
+
+import * as remote from '@electron/remote'
+import { observer, observe } from 'redux-observers'
+import { store, getStore } from 'views/create-store'
+
+const analytics: typeof analyticsType = remote.require('./lib/analytics')
+
+const handleMemberIdChange = (memberId: string | undefined) => {
+  analytics.setUserId(memberId)
+}
+
+const memberIdObserver = observer(
+  (state: { info: { basic: { api_member_id?: string } } }) => state.info.basic.api_member_id,
+  (dispatch, current: string | undefined) => handleMemberIdChange(current),
+)
+
+// The store may already be populated when this service loads (plugin reload, devtools
+// reload), in which case the observer would not fire for the existing value.
+const initialMemberId = getStore('info.basic.api_member_id')
+if (initialMemberId) {
+  handleMemberIdChange(String(initialMemberId))
+}
+
+observe(store, [memberIdObserver])

--- a/views/services/welcome.tsx
+++ b/views/services/welcome.tsx
@@ -16,6 +16,11 @@ const dontShowAgain = () => config.set('poi.update.lastversion', window.POI_VERS
 
 const SWITCHES = [
   {
+    label: 'Send data to Google Analytics',
+    configName: 'poi.misc.analytics',
+    defaultValue: true,
+  },
+  {
     label: 'Send program exceptions to poi team',
     configName: 'poi.misc.exceptionReporting',
     defaultValue: true,


### PR DESCRIPTION
## Background

poi's analytics has been dead for a while. It used Universal Analytics (`analytics.js`, bootstrapped inline from `index.html`), UA was sunset, and the renderer-side service was dropped during the `views/` TypeScript refactor in 216fcff4. What survived was orphaned scaffolding: the `poi.misc.analytics` config flag, the `Send data to Google Analytics` string in all five locales, the CSP allowance for `google-analytics.com`, and the proxy bypass rule. Nothing read any of it.

## Approach

GA4 via the **Measurement Protocol**, called from the main process, rather than `gtag.js` in the renderer.

The renderer route would have meant loading a third-party script into a `file://` origin, extending the CSP and proxy bypass to cover `googletagmanager.com`, and reviving some equivalent of the old `@exponent/electron-cookies` origin override (unmaintained) to get cookie storage working. The Measurement Protocol needs none of that — it is a plain POST, `*.google-analytics.com` is already in `BYPASS_RULES`, and nothing third-party is loaded into the app.

The tradeoff is that the Measurement Protocol does not synthesise sessions or page views. `session_id` and `engagement_time_msec` are therefore attached to every event by hand; without them GA4 silently drops events from most reports. There is no automatic geo/engagement enrichment either.

## What is collected

| Event | When |
|---|---|
| `app_start` | on launch |
| `page_view` | once the admiral's member id is known, against `https://analytics.poooi.app/<version>/` |
| `heartbeat` | every 4 minutes thereafter (same cadence as the old UA setup) |

Every event carries `poi_version`, `platform` and `arch`. The synthetic `analytics.poooi.app` origin is carried over from the UA setup — poi has no real URLs, and this is what made the version breakdown legible in the old property.

## Consent

Opt-out, gated on the existing `poi.misc.analytics` flag. The toggle is read **on every send**, so opting out takes effect immediately rather than at next launch. The switch is restored to advanced settings and to the first-run welcome dialog next to exception reporting.

The GA client id is generated locally with `randomUUID`, identifies an install rather than a person, and is persisted in the new `poi.misc.analyticsClientId`. It is created lazily on first send, so a user who never opts in never gets one.

## Points worth a reviewer's attention

1. **The MP API secret is committed in `lib/analytics.ts`.** It is embedded in every shipped desktop build regardless, and it only permits *writing* events to the property, not reading data — but it does mean anyone can inject junk events. `POI_GA_MEASUREMENT_ID` / `POI_GA_API_SECRET` override it at runtime if we would rather inject it at build time later.
2. **`user_id` is the raw `api_member_id`**, matching the previous behaviour from 23e24ef5. Google's terms prohibit sending PII to GA; a DMM member id is pseudonymous but is a stable cross-service account identifier. Hashing it would preserve the same distinct-accounts analysis if we would prefer that.
3. **Opt-out means `app_start` is sent before the welcome dialog appears** (the dialog is on a 5 second timer). That is the shaky part of an opt-out design under GDPR, more so than the default itself.

## Testing

`lib/__tests__/analytics.spec.ts` covers both gates (missing credentials, opted out), live opt-out without restart, payload shape and query string, client id generation and persistence across launches, page view dedup on a repeated member id, the heartbeat interval, and that network failures are swallowed.

`npm run typecheck` and `eslint` are clean; the full suite is 226 passing across 29 files. Not verified against the live GA property — the payload is built to spec, but landing events end to end has not been confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
