### PR TITLE
fix: extra slot indicator placed on the wrong slot when a slot is empty

### DIFF
--- a/views/components/main/parts/mini-ship/mini-slotitems.tsx
+++ b/views/components/main/parts/mini-ship/mini-slotitems.tsx
@@ -20,8 +20,10 @@ export const MiniSlotitems = ({ shipId }: { shipId: number }) => {
 
   return (
     <ItemName className="item-name slotitems-mini" hide={!equipsData}>
-      {(equipsData ?? []).filter(Boolean).map((equipData, equipIdx) => {
-        const [equip, $equip, onslot] = equipData!
+      {(equipsData ?? []).map((equipData, equipIdx) => {
+        // empty slots are padded with undefined, keep equipIdx aligned with api_maxeq
+        if (!equipData) return null
+        const [equip, $equip, onslot] = equipData
         const equipIconId = ($equip.api_type as number[])[3]
         const level = equip.api_level as number
         const proficiency = equip.api_alv as number | undefined

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -404,7 +404,8 @@ export function equipIsAircraft(equip: APIMstSlotitem | number): boolean {
 }
 
 export function getTyku(
-  equipsData: [Equip, APIMstSlotitem, number | undefined][][],
+  // slots are padded with undefined when empty, see shipEquipDataSelectorFactory
+  equipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
   landbaseStatus = 0,
 ): { basic: number; min: number; max: number } {
   let minTyku = 0
@@ -416,10 +417,11 @@ export function getTyku(
       continue
     }
     for (let j = 0; j < equipsData[i].length; j++) {
-      if (!equipsData[i][j]) {
+      const equipData = equipsData[i][j]
+      if (!equipData) {
         continue
       }
-      const [_equip, $equip, onslot] = equipsData[i][j]
+      const [_equip, $equip, onslot] = equipData
       if ((onslot ?? 0) < 1 || onslot == undefined) {
         continue
       }
@@ -507,7 +509,8 @@ export function getTyku(
 
 export function getSaku25(
   shipsData: [APIShip, APIMstShip][],
-  equipsData: [Equip, APIMstSlotitem, number | undefined][][],
+  // slots are padded with undefined when empty, see shipEquipDataSelectorFactory
+  equipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
 ): { recon: number; radar: number; ship: number; total: number } {
   let reconSaku = 0
   let shipSaku = 0
@@ -517,10 +520,11 @@ export function getSaku25(
     const [_ship] = shipsData[i]
     shipSaku += _ship.api_sakuteki[0]
     for (let j = 0; j < equipsData[i].length; j++) {
-      if (!equipsData[i][j]) {
+      const equipData = equipsData[i][j]
+      if (!equipData) {
         continue
       }
-      const $equip = equipsData[i][j][1]
+      const $equip = equipData[1]
       switch ($equip.api_type[3]) {
         case 9:
           reconSaku += $equip.api_saku
@@ -555,7 +559,8 @@ export function getSaku25(
 
 export function getSaku25a(
   shipsData: [APIShip, APIMstShip][],
-  equipsData: [Equip, APIMstSlotitem, number | undefined][][],
+  // slots are padded with undefined when empty, see shipEquipDataSelectorFactory
+  equipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
   teitokuLv: number,
 ): { ship: number; item: number; teitoku: number; total: number } {
   let shipSaku = 0
@@ -565,10 +570,11 @@ export function getSaku25a(
     const [_ship] = shipsData[i]
     let shipPureSaku = _ship.api_sakuteki[0]
     for (let j = 0; j < equipsData[i].length; j++) {
-      if (!equipsData[i][j]) {
+      const equipData = equipsData[i][j]
+      if (!equipData) {
         continue
       }
-      const $equip = equipsData[i][j][1]
+      const $equip = equipData[1]
       shipPureSaku -= $equip.api_saku
       switch ($equip.api_type[3]) {
         case 7:
@@ -616,7 +622,8 @@ export function getSaku25a(
 
 export function getSaku33(
   shipsData: [APIShip, APIMstShip][],
-  equipsData: [Equip, APIMstSlotitem, number | undefined][][],
+  // slots are padded with undefined when empty, see shipEquipDataSelectorFactory
+  equipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
   teitokuLv: number,
   mapModifier = 1.0,
   slotCount = 6,
@@ -630,10 +637,11 @@ export function getSaku33(
     const [_ship] = shipsData[i]
     let shipPureSaku = _ship.api_sakuteki[0]
     for (let j = 0; j < equipsData[i].length; j++) {
-      if (!equipsData[i][j]) {
+      const equipData = equipsData[i][j]
+      if (!equipData) {
         continue
       }
-      const [_equip, $equip] = equipsData[i][j]
+      const [_equip, $equip] = equipData
       shipPureSaku -= $equip.api_saku
       switch ($equip.api_type[2]) {
         case 8:

--- a/views/utils/selectors/__tests__/equip.spec.ts
+++ b/views/utils/selectors/__tests__/equip.spec.ts
@@ -1,0 +1,74 @@
+import type { ConstState } from 'views/redux/const'
+import type { Equip, EquipsState } from 'views/redux/info/equips'
+import type { Ship, ShipsState } from 'views/redux/info/ships'
+
+import { indexify } from 'views/utils/tools'
+
+import { shipEquipDataSelectorFactory } from '../equip'
+
+const spec = it
+
+const data = require('../../__tests__/fixtures/api_start2.json')
+
+const constState = {
+  $ships: indexify(data.api_mst_ship),
+  $shipTypes: indexify(data.api_mst_stype),
+  $equips: indexify(data.api_mst_slotitem),
+  $equipShip: data.api_mst_equip_ship,
+} satisfies ConstState
+
+// equip ids 101/102/103 hold master items 1/2/3
+const equips: EquipsState = {
+  101: { api_id: 101, api_slotitem_id: 1, api_locked: 0, api_level: 0 } satisfies Equip,
+  102: { api_id: 102, api_slotitem_id: 2, api_locked: 0, api_level: 0 } satisfies Equip,
+  103: { api_id: 103, api_slotitem_id: 3, api_locked: 0, api_level: 0 } satisfies Equip,
+}
+
+// The selector only reads api_slot / api_slot_ex / api_slotnum / api_onslot.
+const makeShip = (
+  api_id: number,
+  api_slot: number[],
+  api_slot_ex: number,
+  api_onslot: number[],
+): Ship =>
+  // @ts-expect-error partial Ship: only the slot-related fields matter here
+  ({ api_id, api_ship_id: 1, api_slotnum: api_slot.length, api_slot, api_slot_ex, api_onslot })
+
+const makeState = (ship: Ship) => {
+  const ships: ShipsState = { [ship.api_id]: ship }
+  return { const: constState, info: { ships, equips } }
+}
+
+const equipDataOf = (shipId: number, ship: Ship) =>
+  // @ts-expect-error partial RootState: only info.ships, info.equips and const are read
+  shipEquipDataSelectorFactory(shipId)(makeState(ship))
+
+describe('shipEquipDataSelectorFactory', () => {
+  spec('keeps empty slots as undefined so indices stay aligned with slots', () => {
+    const ship = makeShip(1, [101, -1, 102, -1], -1, [0, 0, 0, 0])
+    const equipsData = equipDataOf(1, ship)
+
+    // slotnum + 1 (exslot)
+    expect(equipsData).toHaveLength(5)
+    expect(equipsData?.[0]?.[0].api_id).toBe(101)
+    expect(equipsData?.[1]).toBeUndefined()
+    expect(equipsData?.[2]?.[0].api_id).toBe(102)
+    expect(equipsData?.[3]).toBeUndefined()
+  })
+
+  spec('puts the exslot equip at the last index', () => {
+    const ship = makeShip(2, [101, -1, -1, -1], 103, [0, 0, 0, 0])
+    const equipsData = equipDataOf(2, ship)
+
+    expect(equipsData).toHaveLength(5)
+    expect(equipsData?.[4]?.[0].api_id).toBe(103)
+  })
+
+  spec('leaves the last index undefined when the exslot is empty', () => {
+    const ship = makeShip(3, [101, 102, -1, -1], -1, [0, 0, 0, 0])
+    const equipsData = equipDataOf(3, ship)
+
+    expect(equipsData).toHaveLength(5)
+    expect(equipsData?.[4]).toBeUndefined()
+  })
+})

--- a/views/utils/selectors/aggregate.ts
+++ b/views/utils/selectors/aggregate.ts
@@ -92,7 +92,7 @@ export const fleetShipsEquipDataWithEscapeSelectorFactory = memoize((fleetId: nu
         : fleetShipsId
             .filter((shipId) => !escapeStatusSelectorFactory(shipId)(state))
             .map((shipId) => shipEquipDataSelectorFactory(shipId)(state))
-            .filter((data): data is EquipDataWithOnslot[] => data !== undefined),
+            .filter((data): data is (EquipDataWithOnslot | undefined)[] => data !== undefined),
     ),
   ),
 )

--- a/views/utils/selectors/equip.ts
+++ b/views/utils/selectors/equip.ts
@@ -129,7 +129,7 @@ export const shipEquipDataSelectorFactory = memoize((shipId: number) =>
                   : modifiedEquipDataSelectorFactory(equipId)({ state, onslot }),
               ),
               slotnum,
-            ).filter((data): data is EquipDataWithOnslot => data !== undefined),
+            ),
     ),
   ),
 )
@@ -153,7 +153,7 @@ export const landbaseEquipDataSelectorFactory = memoize((landbaseId: number) =>
                   : modifiedEquipDataSelectorFactory(equipId)({ state, onslot }),
               ),
               slotnum,
-            ).filter((data): data is EquipDataWithOnslot => data !== undefined),
+            ),
     ),
   ),
 )


### PR DESCRIPTION
## Problem

In the fleet view, the extra slot (補強増設) `+` badge was drawn on top of the **last equipped item** instead of the extra slot, whenever the ship had any empty slot.

## Root cause

Not in the rendering component. `shipEquipDataSelectorFactory` and `landbaseEquipDataSelectorFactory` both ended with `.filter((data) => data !== undefined)`, added during a TypeScript refactor to make the result a plain tuple array. That silently broke the contract documented directly above them:

```
// length is always slotnum+1, which is all slots plus exslot
// Slot is padded with undefined for being empty or not fount in _equips
```

With the holes dropped, array indices no longer corresponded to slot indices, so `Slotitems`' `isExslot = equipIdx === equipsData.length - 1` matched the last *equipped* item.

## Changes

- Drop the `.filter` in both selectors, restoring the padded-array contract.
- `getTyku` / `getSaku25` / `getSaku25a` / `getSaku33` signatures accept holes. Their loops already skipped falsy entries at runtime, so no computed value changes; the element access was hoisted into a local so TypeScript narrows it.
- `fleetShipsEquipDataWithEscapeSelectorFactory`'s type predicate no longer claims the holes are gone.
- `mini-slotitems` skips holes inside `map` instead of `.filter(Boolean)`, keeping `equipIdx` aligned with `api_maxeq`.
- New `views/utils/selectors/__tests__/equip.spec.ts` pinning the padding contract: empty middle slot, extra slot at the last index, empty extra slot.

Same root cause, also fixed: the empty-slot capacity badge renders again, the mini tooltip's onslot warning uses the right `api_maxeq`, and land-base slots read the right `api_cond` / `api_state` when a plane slot is empty.

## Verification

`npm run typecheck` clean; `npm test` 231 passed / 30 suites. Verified by types and tests — a visual check in-game is still worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
