### PR TITLE
refactor: use an enum for ship label status and show every status

### DIFF
--- a/views/components/ship-parts/statuslabel.tsx
+++ b/views/components/ship-parts/statuslabel.tsx
@@ -1,5 +1,6 @@
 import type { FcdShipTagState } from 'views/redux/fcd'
 import type { RootState } from 'views/redux/reducer-factory'
+import type { ShipLabel } from 'views/utils/game-utils'
 
 import { Intent, Position, Tag, Tooltip } from '@blueprintjs/core'
 import { isEqual } from 'lodash'
@@ -7,10 +8,26 @@ import React, { memo } from 'react'
 import FontAwesome from 'react-fontawesome'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import { ShipLabelStatus } from 'views/utils/game-utils'
 
-const TEXTS = [['Retreated'], ['Repairing'], ['Resupply Needed']]
-const INTENTS = [Intent.WARNING, Intent.NONE, Intent.WARNING]
-const ICONS = ['reply', 'wrench', 'database']
+const TEXTS: Record<ShipLabelStatus, string> = {
+  [ShipLabelStatus.Retreated]: 'Retreated',
+  [ShipLabelStatus.Repairing]: 'Repairing',
+  [ShipLabelStatus.ResupplyNeeded]: 'Resupply Needed',
+  [ShipLabelStatus.ShipTag]: 'Ship tag',
+}
+const INTENTS: Record<ShipLabelStatus, Intent> = {
+  [ShipLabelStatus.Retreated]: Intent.WARNING,
+  [ShipLabelStatus.Repairing]: Intent.NONE,
+  [ShipLabelStatus.ResupplyNeeded]: Intent.WARNING,
+  [ShipLabelStatus.ShipTag]: Intent.NONE,
+}
+const ICONS: Record<ShipLabelStatus, string> = {
+  [ShipLabelStatus.Retreated]: 'reply',
+  [ShipLabelStatus.Repairing]: 'wrench',
+  [ShipLabelStatus.ResupplyNeeded]: 'database',
+  [ShipLabelStatus.ShipTag]: 'tag',
+}
 
 const initState: FcdShipTagState = {
   color: [],
@@ -19,36 +36,52 @@ const initState: FcdShipTagState = {
 }
 
 interface StatusLabelProps {
-  label?: number | null
+  label?: ShipLabel[] | null
 }
 
-export const StatusLabel = memo(({ label: i }: StatusLabelProps) => {
+export const StatusLabel = memo(({ label: labels }: StatusLabelProps) => {
   const { t, i18n } = useTranslation('main')
   const shipTag = useSelector((state: RootState) => state.fcd.shiptag ?? initState, isEqual)
   const { color, mapname, fleetname } = shipTag
   const language = i18n.language
 
-  if (i != null && i >= 0) {
-    return (
-      <Tooltip
-        position={Position.TOP}
-        content={
-          i > 2
-            ? `${(fleetname[language] ?? [])[i - 3] ?? t('main:Ship tag')} - ${mapname[i - 3] || i - 2}`
-            : t(`main:${TEXTS[i]}`)
-        }
-      >
-        <Tag
-          minimal
-          intent={INTENTS[i] ?? Intent.NONE}
-          style={i > 2 ? { color: color[i - 3] } : {}}
-        >
-          <FontAwesome key={0} name={ICONS[i] ?? 'tag'} />
-        </Tag>
-      </Tooltip>
-    )
-  } else {
+  if (!labels?.length) {
     return null
   }
+
+  const describe = ({ status, sallyArea }: ShipLabel): string => {
+    if (status === ShipLabelStatus.ShipTag && sallyArea) {
+      const tagIndex = sallyArea - 1
+      const name = (fleetname[language] ?? [])[tagIndex] ?? t('main:Ship tag')
+      return `${name} - ${mapname[tagIndex] || sallyArea}`
+    }
+    return t(`main:${TEXTS[status]}`)
+  }
+
+  // the first label is the most significant one, it decides how the tag looks
+  const [{ status: primary, sallyArea }] = labels
+
+  return (
+    <Tooltip
+      position={Position.TOP}
+      content={
+        <>
+          {labels.map((label) => (
+            <div key={label.status}>{describe(label)}</div>
+          ))}
+        </>
+      }
+    >
+      <Tag
+        minimal
+        intent={INTENTS[primary] ?? Intent.NONE}
+        style={
+          primary === ShipLabelStatus.ShipTag && sallyArea ? { color: color[sallyArea - 1] } : {}
+        }
+      >
+        <FontAwesome key={0} name={ICONS[primary] ?? 'tag'} />
+      </Tag>
+    </Tooltip>
+  )
 })
 StatusLabel.displayName = 'StatusLabel'

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -335,38 +335,56 @@ export const getSpeedLabel = (speed: number): string => speedInterpretation[spee
 
 export const getSpeedStyle = (speed: number): React.CSSProperties => speedStyles[speed] || {}
 
-export function getStatusStyle(status: number | null | undefined): React.CSSProperties {
-  if (status != null) {
-    const flag = status == 0 || status == 1
-    if (flag) {
-      return { opacity: 0.4 }
-    }
+export enum ShipLabelStatus {
+  Retreated = 'Retreated',
+  Repairing = 'Repairing',
+  ResupplyNeeded = 'ResupplyNeeded',
+  ShipTag = 'ShipTag',
+}
+
+export interface ShipLabel {
+  status: ShipLabelStatus
+  /** `api_sally_area`, only set for `ShipLabelStatus.ShipTag` */
+  sallyArea?: number
+}
+
+const DIMMED_STATUSES = [ShipLabelStatus.Retreated, ShipLabelStatus.Repairing]
+
+export function getStatusStyle(labels: ShipLabel[] | null | undefined): React.CSSProperties {
+  if (labels?.some(({ status }) => DIMMED_STATUSES.includes(status))) {
+    return { opacity: 0.4 }
   }
   return {}
 }
 
+// NOTE: order matters, the first label decides the icon / intent shown on the tag.
 export function getShipLabelStatus(
   ship: APIShip | undefined,
   $ship: APIMstShip | undefined,
   inRepair: boolean,
   escaped: boolean,
-): number {
+): ShipLabel[] {
   if (!ship || !$ship) {
-    return -1
+    return []
   }
+  const labels: ShipLabel[] = []
   if (escaped) {
-    return 0
-  } else if (inRepair) {
-    return 1
-  } else if (
+    labels.push({ status: ShipLabelStatus.Retreated })
+  }
+  if (inRepair) {
+    labels.push({ status: ShipLabelStatus.Repairing })
+  }
+  if (
     Math.min(ship.api_fuel / ($ship.api_fuel_max ?? 1), ship.api_bull / ($ship.api_bull_max ?? 1)) <
     1
   ) {
-    return 2
-  } else if ((ship.api_sally_area ?? 0) > 0) {
-    return (ship.api_sally_area ?? 0) + 2
+    labels.push({ status: ShipLabelStatus.ResupplyNeeded })
   }
-  return -1
+  const sallyArea = ship.api_sally_area ?? 0
+  if (sallyArea > 0) {
+    labels.push({ status: ShipLabelStatus.ShipTag, sallyArea })
+  }
+  return labels
 }
 
 export function getHpStyle(percent: number): MaterialIntent {


### PR DESCRIPTION
## What

`getShipLabelStatus` returned a magic number: `-1` for "nothing", `0..2` for retreated / repairing / resupply needed, and anything above `2` for a ship tag whose `api_sally_area` was offset by 2. Consumers then had to decode that offset back out (`i - 3`, `i - 2`) to index into the fcd ship tag tables.

It also used an `else if` chain, so only the first matching state was ever reported — a repairing ship that was also low on supplies looked like it was merely repairing, and a tagged ship lost its tag whenever anything else applied.

## Changes

- `views/utils/game-utils.ts`: added a `ShipLabelStatus` string enum and a `ShipLabel` carrier (`{ status, sallyArea? }`). `getShipLabelStatus` now returns `ShipLabel[]`, collecting every state that applies, and `api_sally_area` rides along unencoded.
- `getStatusStyle` takes the label list and dims for retreated / repairing — same rule as the old `status == 0 || status == 1`.
- `views/components/ship-parts/statuslabel.tsx`: text / intent / icon tables became `Record<ShipLabelStatus, …>` lookups instead of positional arrays, and the tooltip renders one line per applicable state.

The tag icon, intent and color still come from the first (highest priority) state, so the label itself looks the same as before; only the tooltip gained the extra lines. The two call sites (`ship-item.tsx`, `mini-ship-row.tsx`) pass the value straight through and needed no edits.

## Testing

`npm run typecheck` and ESLint on the touched files pass. There is no existing test coverage for `game-utils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)