### PR TITLE
fix(main): keep the pressed look for the selected fleet tab

### DIFF
--- a/views/components/ship-parts/landbase-button.tsx
+++ b/views/components/ship-parts/landbase-button.tsx
@@ -10,6 +10,8 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { css, styled } from 'styled-components'
 
+import { fleetSwitchButtonStyle } from './styled-components'
+
 const AirbaseLabel = styled(Tag)`
   flex: none;
   margin: 2px;
@@ -50,6 +52,8 @@ const LandbaseButtonContainer = styled(ButtonGroup)<{ isMini?: boolean }>`
             overflow: hidden;
           }
         `}
+
+  ${fleetSwitchButtonStyle}
 `
 
 const fatiguedLabel = (

--- a/views/components/ship-parts/styled-components.tsx
+++ b/views/components/ship-parts/styled-components.tsx
@@ -19,6 +19,41 @@ export const overAvatarText = ({
   text-shadow: #000 0 0 ${shadowBlur};
 `
 
+// Blueprint styles an intent button as a solid chip but a no-intent one as a
+// light surface (and assets/css/blueprint-vibrant.css makes that surface
+// translucent on top), so an `Intent.NONE` fleet sat visibly "unpressed" next
+// to its neighbours and the state colors read as selection instead. Patch the
+// no-intent buttons only, with blueprint's own solid `bp6-intent-default`
+// colors, so every state shares one shape and only `.bp6-active` looks pressed.
+// The `!important` matches the theme's own `!important` background rules.
+const plainFleetSwitchButton = `.bp6-button:not([class*='bp6-intent-'], :disabled, .bp6-disabled)`
+
+export const fleetSwitchButtonStyle = css`
+  ${plainFleetSwitchButton} {
+    background-color: var(--bp-intent-default-rest) !important;
+    box-shadow:
+      inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
+      0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
+    color: var(--bp-intent-default-foreground);
+  }
+  ${plainFleetSwitchButton}:hover {
+    background-color: var(--bp-intent-default-hover) !important;
+    box-shadow:
+      inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
+      0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
+  }
+  ${plainFleetSwitchButton}:active,
+  ${plainFleetSwitchButton}.bp6-active {
+    background-color: var(--bp-intent-default-active) !important;
+    box-shadow:
+      inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
+      0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
+  }
+`
+
 export const ShipCard = styled(Card)`
   display: flex;
   flex-direction: column;
@@ -104,6 +139,8 @@ export const FleetNameButton = styled(ButtonGroup)`
     flex: 1;
     overflow: hidden;
   }
+
+  ${fleetSwitchButtonStyle}
 `
 
 export const AirbaseArea = styled.div`


### PR DESCRIPTION
## Problem

Blueprint styles an intent button as a solid chip, but a no-intent button as a light surface — and `assets/css/blueprint-vibrant.css` makes that surface translucent on top of it. A fleet whose state maps to `Intent.NONE` therefore sat visibly flat next to its neighbours, while the intent-colored ones looked filled. The result was that the fleet *state* colors read as selection, and the actually selected tab did not stand out.

## Change

Patch the no-intent fleet / airbase switch buttons only, giving them Blueprint's own solid `bp6-intent-default` colors (rest / hover / active plus the matching border shadow). Every state now shares one shape, and the only thing that changes with selection is the usual rest → active step.

- `!important` on the backgrounds is needed to beat the equally-`!important` no-intent rules in the vibrant theme.
- Disabled buttons are excluded from the selector, so out-of-range fleets keep their normal disabled look.
- Shared via `fleetSwitchButtonStyle`, applied by `FleetNameButton` (ship view + main-view mini row) and `LandbaseButtonContainer`.

No component logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
