### PR TITLE
refactor: name the game state numbers with enums

### DIFF
--- a/views/components/main/parts/construction-panel.tsx
+++ b/views/components/main/parts/construction-panel.tsx
@@ -11,6 +11,7 @@ import { Avatar } from 'views/components/etc/avatar'
 import { MaterialIcon } from 'views/components/etc/icon'
 import { getStore } from 'views/create-store'
 import i18next from 'views/env-parts/i18next'
+import { ConstructionDockState } from 'views/utils/game-utils'
 
 import { CountdownNotifierLabel } from './countdown-timer'
 import {
@@ -23,9 +24,9 @@ import {
   EmptyDockWrapper,
 } from './styled-components'
 
-const EmptyDock = ({ state }: { state: number }) => (
+const EmptyDock = ({ state }: { state: ConstructionDockState }) => (
   <EmptyDockWrapper className="empty-dock">
-    <FA name={state === 0 ? 'inbox' : 'lock'} />
+    <FA name={state === ConstructionDockState.Empty ? 'inbox' : 'lock'} />
   </EmptyDockWrapper>
 )
 
@@ -86,15 +87,15 @@ export const ConstructionPanel = ({ editable }: { editable?: boolean }) => {
       <Panel>
         {range(4).map((i) => {
           const dock = constructions[i] ?? {
-            api_state: -1,
+            api_state: ConstructionDockState.Locked,
             api_complete_time: 0,
           }
-          const isInUse = dock.api_state > 0
+          const isInUse = dock.api_state > ConstructionDockState.Empty
           const isLSC = isInUse && (dock.api_item1 ?? 0) >= 1000
           const dockName =
-            dock.api_state === -1
+            dock.api_state === ConstructionDockState.Locked
               ? t('main:Locked')
-              : dock.api_state === 0
+              : dock.api_state === ConstructionDockState.Empty
                 ? t('main:Empty')
                 : getDockShipName(i, '???')
           const completeTime = isInUse ? dock.api_complete_time : -1
@@ -126,7 +127,7 @@ export const ConstructionPanel = ({ editable }: { editable?: boolean }) => {
               <DockInnerWrapper>
                 {enableAvatar && (
                   <>
-                    {dock.api_state > 0 ? (
+                    {dock.api_state > ConstructionDockState.Empty ? (
                       <Avatar height={20} mstId={constructions?.[i]?.api_created_ship_id ?? 0} />
                     ) : (
                       <EmptyDock state={dock.api_state} />

--- a/views/components/main/parts/mini-ship/mini-squard-row.tsx
+++ b/views/components/main/parts/mini-ship/mini-squard-row.tsx
@@ -1,4 +1,3 @@
-import type { Intent } from '@blueprintjs/core'
 import type { RootState } from 'views/redux/reducer-factory'
 
 import { memoize, get } from 'lodash'
@@ -14,6 +13,7 @@ import {
   getTyku,
   LBAC_INTENTS,
   LBAC_STATUS_NAMES,
+  toAirbaseActionKind,
 } from 'views/utils/game-utils'
 import { landbaseSelectorFactory, landbaseEquipDataSelectorFactory } from 'views/utils/selectors'
 
@@ -68,9 +68,9 @@ export const MiniSquardRow = ({
 
   const hideShipName = enableAvatar && compact
   const lb = landbase
-  const api_action_kind = lb?.api_action_kind ?? 0
+  const actionKind = toAirbaseActionKind(lb?.api_action_kind)
   const api_name = lb?.api_name ?? ''
-  const tyku = getTyku(equipsData ? [equipsData] : [], api_action_kind)
+  const tyku = getTyku(equipsData ? [equipsData] : [], actionKind)
   return (
     <ShipTile className="ship-tile">
       <MiniShipItem className="ship-item" avatar={enableAvatar} shipName={!hideShipName} isLBAC>
@@ -101,12 +101,8 @@ export const MiniSquardRow = ({
             </ShipFP>
           </>
         )}
-        <LandBaseStatTag
-          className="landbase-status"
-          minimal
-          intent={LBAC_INTENTS[api_action_kind] as Intent}
-        >
-          {t(LBAC_STATUS_NAMES[api_action_kind])}
+        <LandBaseStatTag className="landbase-status" minimal intent={LBAC_INTENTS[actionKind]}>
+          {t(LBAC_STATUS_NAMES[actionKind])}
         </LandBaseStatTag>
         <LandBaseState className="ship-stat landbase-stat">
           <ShipStateText>

--- a/views/components/main/parts/repair-panel.tsx
+++ b/views/components/main/parts/repair-panel.tsx
@@ -15,6 +15,7 @@ import { styled } from 'styled-components'
 import { Avatar } from 'views/components/etc/avatar'
 import { getStore } from 'views/create-store'
 import { ROOT } from 'views/env'
+import { RepairDockState } from 'views/utils/game-utils'
 import {
   repairsSelector,
   constSelector,
@@ -53,9 +54,9 @@ const inRepairShipsDataSelector = createSelector(
   (inRepairShipsId, ships) => inRepairShipsId?.map((shipId) => ships[shipId]) ?? [],
 )
 
-const EmptyDock = ({ state }: { state: number }) => (
+const EmptyDock = ({ state }: { state: RepairDockState }) => (
   <EmptyDockWrapper className="empty-dock">
-    <FA name={state === 0 ? 'bath' : 'lock'} />
+    <FA name={state === RepairDockState.Empty ? 'bath' : 'lock'} />
   </EmptyDockWrapper>
 )
 
@@ -123,12 +124,12 @@ export const RepairPanel = ({ editable }: { editable?: boolean }) => {
             api_item3: 0,
             api_item4: 0,
             api_ship_id: 0,
-            api_state: 0,
+            api_state: RepairDockState.Empty,
           }
           const dock = (repairs[i] as RepairDock | undefined) ?? emptyRepair
           const completeTime = dock.api_complete_time || -1
           let hpPercentage: number | undefined
-          if (dock.api_state > 0) {
+          if (dock.api_state > RepairDockState.Empty) {
             hpPercentage =
               (100 * get(ships, [dock.api_ship_id, 'api_nowhp'])) /
               get(ships, [dock.api_ship_id, 'api_maxhp'])
@@ -189,9 +190,9 @@ const RepairPanelRow = ({
   const notifyMessage = (names: string) => `${names} ${t('main:repair completed')}`
 
   const dockName =
-    dock.api_state === -1
+    dock.api_state === RepairDockState.Locked
       ? t('main:Locked')
-      : dock.api_state === 0
+      : dock.api_state === RepairDockState.Empty
         ? t('main:Empty')
         : t(`resources:${$ships?.[ships[dock.api_ship_id]?.api_ship_id]?.api_name}`)
 
@@ -200,7 +201,7 @@ const RepairPanelRow = ({
       <DockInnerWrapper>
         {enableAvatar && (
           <>
-            {dock.api_state > 0 ? (
+            {dock.api_state > RepairDockState.Empty ? (
               <Avatar
                 height={20}
                 mstId={ships[dock.api_ship_id]?.api_ship_id}
@@ -216,7 +217,7 @@ const RepairPanelRow = ({
         </DockName>
         <Tooltip
           position={Position.LEFT}
-          disabled={dock.api_state < 0}
+          disabled={dock.api_state < RepairDockState.Empty}
           content={
             <div>
               <strong>{t('main:Finish By')}: </strong>

--- a/views/components/main/parts/task-panel.tsx
+++ b/views/components/main/parts/task-panel.tsx
@@ -17,6 +17,7 @@ import {
   type QuestRecord,
   type SubgoalRecord,
 } from 'views/redux/info/quests'
+import { QuestProgressFlag, QuestState } from 'views/utils/game-utils'
 import {
   configLayoutSelector,
   configReverseLayoutSelector,
@@ -90,13 +91,11 @@ interface Quest {
 function getIntentByProgress(quest: Quest | undefined): Intent {
   if (!quest) return Intent.NONE
   const { api_progress_flag, api_state } = quest
-  if (api_state === 3) return 'success' as Intent
+  if (api_state === QuestState.Completed) return Intent.SUCCESS
   switch (api_progress_flag) {
-    case 0:
-      return Intent.NONE
-    case 1:
+    case QuestProgressFlag.Half:
       return Intent.WARNING
-    case 2:
+    case QuestProgressFlag.Most:
       return Intent.PRIMARY
     default:
       return Intent.NONE
@@ -106,11 +105,11 @@ function getIntentByProgress(quest: Quest | undefined): Intent {
 function progressLabelText(quest: Quest | undefined): React.ReactNode {
   if (!quest) return ''
   const { api_progress_flag, api_state } = quest
-  if (api_state === 3) return <Trans>main:Completed</Trans>
+  if (api_state === QuestState.Completed) return <Trans>main:Completed</Trans>
   switch (api_progress_flag) {
-    case 1:
+    case QuestProgressFlag.Half:
       return '50%'
-    case 2:
+    case QuestProgressFlag.Most:
       return '80%'
     default:
       return <Trans>main:In progress</Trans>

--- a/views/components/ship-parts/landbase-button.tsx
+++ b/views/components/ship-parts/landbase-button.tsx
@@ -9,6 +9,12 @@ import FontAwesome from 'react-fontawesome'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { css, styled } from 'styled-components'
+import {
+  AIRBASE_ACTING_KINDS,
+  PlaneCond,
+  PlaneState,
+  toAirbaseActionKind,
+} from 'views/utils/game-utils'
 
 import { fleetSwitchButtonStyle } from './styled-components'
 
@@ -95,14 +101,14 @@ const getAirbaseData = memoizeOne(
       .filter((a) => !!mapareas[a.api_area_id ?? ''])
       .map((base) => {
         const planes = _(base.api_plane_info ?? []).compact()
-        // api_cond is 0 on some responses; only 2+ means the squadron is fatigued.
-        const squardCond = planes.map((plane) => plane.api_cond || 1).max() ?? 1
-        const squardState = planes.map('api_state').max() ?? 0
+        const squardCond =
+          planes.map((plane) => plane.api_cond || PlaneCond.Normal).max() ?? PlaneCond.Normal
+        const squardState = planes.map('api_state').max() ?? PlaneState.Empty
         const needSupply = planes.some((plane) => plane.api_count !== plane.api_max_count)
-        const noAction = ![1, 2].includes(base.api_action_kind ?? -1)
-        const fatigued = squardCond > 1
-        const empty = squardState < 1
-        const relocating = squardState > 1
+        const noAction = !AIRBASE_ACTING_KINDS.includes(toAirbaseActionKind(base.api_action_kind))
+        const fatigued = squardCond > PlaneCond.Normal
+        const empty = squardState < PlaneState.Ready
+        const relocating = squardState > PlaneState.Ready
         return {
           areaId: String(base.api_area_id),
           squadId: base.api_rid ?? 0,
@@ -114,14 +120,14 @@ const getAirbaseData = memoizeOne(
           squardState,
           squardCond,
           ready: !fatigued && !empty && !relocating && !needSupply && !noAction,
-          allEmpty: planes.every((plane) => plane.api_state === 0),
+          allEmpty: planes.every((plane) => plane.api_state === PlaneState.Empty),
         }
       })
 
     const activeSquads = squadInfo.filter((squad) => !squad.allEmpty)
     const needSupply = activeSquads.some((squad) => squad.needSupply)
-    const squardState = activeSquads.map('squardState').max() ?? 1
-    const squardCond = activeSquads.map('squardCond').max() ?? 1
+    const squardState = activeSquads.map('squardState').max() ?? PlaneState.Ready
+    const squardCond = activeSquads.map('squardCond').max() ?? PlaneCond.Normal
     const noAction = activeSquads.some((squad) => squad.noAction)
 
     const airbaseProps = squadInfo.groupBy('areaId').value()
@@ -130,9 +136,9 @@ const getAirbaseData = memoizeOne(
     let intent: Intent
     if (sortie || noAction) {
       intent = Intent.NONE
-    } else if (squardCond > 1) {
+    } else if (squardCond > PlaneCond.Normal) {
       intent = Intent.DANGER
-    } else if (squardState !== 1 || needSupply) {
+    } else if (squardState !== PlaneState.Ready || needSupply) {
       intent = Intent.WARNING
     } else {
       intent = Intent.SUCCESS

--- a/views/components/ship/lbac-view.tsx
+++ b/views/components/ship/lbac-view.tsx
@@ -1,4 +1,3 @@
-import type { Intent } from '@blueprintjs/core'
 import type { RootState } from 'views/redux/reducer-factory'
 
 import { Position, ProgressBar, Tag, Tooltip } from '@blueprintjs/core'
@@ -26,6 +25,7 @@ import {
   getTyku,
   LBAC_INTENTS,
   LBAC_STATUS_NAMES,
+  toAirbaseActionKind,
 } from 'views/utils/game-utils'
 import { landbaseEquipDataSelectorFactory, landbaseSelectorFactory } from 'views/utils/selectors'
 
@@ -50,14 +50,15 @@ export const SquardRow = memo(({ squardId, enableAvatar, compact }: SquardRowPro
   const { landbase, equipsData } = useSelector((state: RootState) => selector(state))
 
   const {
-    api_action_kind = 0,
+    api_action_kind: apiActionKind,
     api_distance,
     api_name = '',
     api_nowhp = 200,
     api_maxhp = 200,
   } = landbase ?? {}
   const { api_base = 0, api_bonus = 0 } = api_distance ?? {}
-  const tyku = getTyku([equipsData!], api_action_kind)
+  const actionKind = toAirbaseActionKind(apiActionKind)
+  const tyku = getTyku([equipsData!], actionKind)
   const hpPercentage = (api_nowhp / api_maxhp) * 100
   const hideLBACName = enableAvatar && compact
 
@@ -112,8 +113,8 @@ export const SquardRow = memo(({ squardId, enableAvatar, compact }: SquardRowPro
           {api_nowhp} / {api_maxhp}
         </ShipHP>
         <ShipStatusContainer className="lbac-status-label">
-          <Tag className="landbase-status" minimal intent={LBAC_INTENTS[api_action_kind] as Intent}>
-            {t(LBAC_STATUS_NAMES[api_action_kind])}
+          <Tag className="landbase-status" minimal intent={LBAC_INTENTS[actionKind]}>
+            {t(LBAC_STATUS_NAMES[actionKind])}
           </Tag>
         </ShipStatusContainer>
         <ShipHPProgress className="hp-progress">

--- a/views/components/ship/slotitems.tsx
+++ b/views/components/ship/slotitems.tsx
@@ -16,7 +16,7 @@ import {
   SlotItemContainer,
   SlotItems,
 } from 'views/components/ship-parts/styled-components'
-import { equipIsAircraft } from 'views/utils/game-utils'
+import { equipIsAircraft, PlaneCond, PlaneState } from 'views/utils/game-utils'
 import {
   landbaseEquipDataSelectorFactory,
   landbaseSelectorFactory,
@@ -152,10 +152,12 @@ export const LandbaseSlotitems = memo(
           const onslotWarning = !!(equipData && onslot != null && onslot < maxOnslot)
           const onslotText = equipData ? onslot : maxOnslot
           const iconStyle: React.CSSProperties = {
-            opacity: api_state[equipIdx] === 2 ? 0.5 : undefined,
+            opacity: api_state[equipIdx] === PlaneState.Relocating ? 0.5 : undefined,
             filter:
-              (api_cond[equipIdx] ?? 0) > 1
-                ? `drop-shadow(0px 0px 4px ${api_cond[equipIdx] === 2 ? '#FB8C00' : '#E53935'})`
+              (api_cond[equipIdx] ?? 0) > PlaneCond.Normal
+                ? `drop-shadow(0px 0px 4px ${
+                    api_cond[equipIdx] === PlaneCond.Tired ? '#FB8C00' : '#E53935'
+                  })`
                 : undefined,
           }
           const itemOverlay = equipData && $equip && equip && (
@@ -182,7 +184,7 @@ export const LandbaseSlotitems = memo(
                     className="slotitem-onslot-mini"
                     intent={onslotWarning ? Intent.WARNING : Intent.NONE}
                     minimal
-                    hide={!showOnslot || api_state[equipIdx] !== 1}
+                    hide={!showOnslot || api_state[equipIdx] !== PlaneState.Ready}
                   >
                     {onslotText}
                   </OnSlotMini>

--- a/views/redux/info/constructions.ts
+++ b/views/redux/info/constructions.ts
@@ -1,6 +1,7 @@
 import type { APIKdock } from 'kcsapi/api_get_member/require_info/response'
 
 import { createSlice } from '@reduxjs/toolkit'
+import { ConstructionDockState } from 'views/utils/game-utils'
 
 import {
   createAPIGetMemberKdockResponseAction,
@@ -12,7 +13,7 @@ import {
 const completeConstruction = {
   api_complete_time: 0,
   api_complete_time_str: '0',
-  api_state: 3,
+  api_state: ConstructionDockState.Completed,
 }
 
 const constructionsSlice = createSlice({

--- a/views/redux/info/quests/index.ts
+++ b/views/redux/info/quests/index.ts
@@ -5,6 +5,7 @@ import CSON from 'cson'
 import { cloneDeep } from 'lodash'
 import path from 'path'
 import Scheduler from 'views/services/scheduler'
+import { QuestState } from 'views/utils/game-utils'
 import { copyIfSame } from 'views/utils/tools'
 
 import type { QuestGoal, QuestRecord, QuestsState } from './types'
@@ -144,7 +145,7 @@ const questsSlice = createSlice({
 
           // Active quests
           activeQuests = copyIfSame(activeQuests, state.activeQuests)
-          if (api_state >= 2) {
+          if (api_state >= QuestState.InProgress) {
             activeQuests[api_no] = { detail: q, time: now }
           } else {
             delete activeQuests[api_no]

--- a/views/redux/info/quests/records.ts
+++ b/views/redux/info/quests/records.ts
@@ -1,6 +1,7 @@
 import type { APIList } from 'kcsapi/api_get_member/questlist/response'
 
 import { sortBy, mapValues, forEach, values, fromPairs, range } from 'lodash'
+import { QuestState } from 'views/utils/game-utils'
 
 import type { QuestOptions, QuestEvent } from '../../actions'
 import type { ActiveQuest, GoalKey, QuestGoal, QuestRecord, SubgoalRecord } from './types'
@@ -261,7 +262,7 @@ export function updateRecordProgress(record: QuestRecord, bodyQuest: APIList): Q
       subgoal.count,
       subgoal.required,
       api_progress_flag || 0,
-      api_state === 3,
+      api_state === QuestState.Completed,
     )
     if (count !== subgoal.count) {
       return {

--- a/views/redux/info/repairs.ts
+++ b/views/redux/info/repairs.ts
@@ -3,6 +3,7 @@ import type { Dispatch } from 'redux'
 import { createSlice } from '@reduxjs/toolkit'
 import _ from 'lodash'
 import { observer } from 'redux-observers'
+import { RepairDockState } from 'views/utils/game-utils'
 import { compareUpdate } from 'views/utils/tools'
 
 import type { RootState } from '../reducer-factory'
@@ -94,8 +95,8 @@ export const dockingCompleteObserver = observer<RootState, RepairsState>(
         // sanity check: now current position should be empty
         repairDataCur.api_ship_id === 0 &&
         // state transition: docking complete
-        repairDataPrev.api_state === 1 &&
-        repairDataCur.api_state === 0
+        repairDataPrev.api_state === RepairDockState.Repairing &&
+        repairDataCur.api_state === RepairDockState.Empty
       ) {
         dispatch(createInfoShipsRepairCompletedAction({ api_ship_id: rstId }))
       }

--- a/views/services/event-sortie-check.ts
+++ b/views/services/event-sortie-check.ts
@@ -3,6 +3,7 @@ import type { Ship } from 'views/redux/info/ships'
 import { getStore } from 'views/create-store'
 import { config } from 'views/env'
 import i18next from 'views/env-parts/i18next'
+import { UNAVAILABLE_DECK_STATES } from 'views/utils/game-utils'
 
 import { fleetShipsDataSelectorFactory, fleetStateSelectorFactory } from '../utils/selectors'
 
@@ -48,7 +49,9 @@ window.addEventListener('game.request', (e) => {
     }
 
     fleets
-      .filter((fleetId) => ![3, 4, 5].includes(fleetStateSelectorFactory(fleetId)(state)))
+      .filter(
+        (fleetId) => !UNAVAILABLE_DECK_STATES.includes(fleetStateSelectorFactory(fleetId)(state)),
+      )
       .forEach((fleetId) => {
         flag = flag || getFleetFlag(fleetShipsDataSelectorFactory(fleetId)(state))
       })

--- a/views/services/sortie-unused-slot-check.ts
+++ b/views/services/sortie-unused-slot-check.ts
@@ -3,6 +3,7 @@ import type { Ship } from 'views/redux/info/ships'
 import { getStore } from 'views/create-store'
 import { config } from 'views/env'
 import i18next from 'views/env-parts/i18next'
+import { UNAVAILABLE_DECK_STATES } from 'views/utils/game-utils'
 
 import { fleetStateSelectorFactory } from '../utils/selectors'
 
@@ -31,7 +32,9 @@ window.addEventListener('game.response', (e) => {
   }
 
   const flag = fleets
-    .filter((_, fleetId) => ![3, 4, 5].includes(fleetStateSelectorFactory(fleetId)(state)))
+    .filter(
+      (_, fleetId) => !UNAVAILABLE_DECK_STATES.includes(fleetStateSelectorFactory(fleetId)(state)),
+    )
     .flatMap((fleet) => fleet.api_ship)
     .some((shipId) => checkSlot(ships[shipId]))
 

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -731,34 +731,140 @@ export const getSlotitemCount = (slotitems: EquipsState): number => {
   ).length
 }
 
-export const FLEET_INTENTS = [
-  Intent.SUCCESS,
-  Intent.WARNING,
-  Intent.DANGER,
-  Intent.NONE,
-  Intent.PRIMARY,
-  Intent.NONE,
-]
+// What a fleet is busy with, as computed by `getDeckState`. The values are
+// ordered: a fleet gets the highest state that applies to it, and states from
+// `Repairing` up mean the fleet is not available for a sortie. Kept numeric
+// (and in the original order) because plugins read these values.
+export enum DeckState {
+  /** Ready to sortie */
+  Ready = 0,
+  /** Tired, moderately damaged or not resupplied */
+  Warning = 1,
+  /** Badly fatigued or heavily damaged */
+  Danger = 2,
+  /** A member is in a repair dock */
+  Repairing = 3,
+  /** Away on an expedition */
+  Expedition = 4,
+  /** Sortied */
+  Sortie = 5,
+}
 
-export const getFleetIntent = (state: number, disabled: boolean): Intent =>
-  state >= 0 && state <= 5 && !disabled ? FLEET_INTENTS[state] : Intent.NONE
+// A fleet in one of these states can't be sent out as it is
+export const UNAVAILABLE_DECK_STATES = [DeckState.Repairing, DeckState.Expedition, DeckState.Sortie]
+
+export const FLEET_INTENTS: Record<DeckState, Intent> = {
+  [DeckState.Ready]: Intent.SUCCESS,
+  [DeckState.Warning]: Intent.WARNING,
+  [DeckState.Danger]: Intent.DANGER,
+  [DeckState.Repairing]: Intent.NONE,
+  [DeckState.Expedition]: Intent.PRIMARY,
+  [DeckState.Sortie]: Intent.NONE,
+}
+
+export const getFleetIntent = (state: DeckState, disabled: boolean): Intent =>
+  disabled ? Intent.NONE : (FLEET_INTENTS[state] ?? Intent.NONE)
 
 export const DEFAULT_FLEET_NAMES = ['I', 'II', 'III', 'IV']
 
-export const LBAC_INTENTS = [
-  Intent.NONE,
-  Intent.DANGER,
-  Intent.WARNING,
-  Intent.PRIMARY,
-  Intent.SUCCESS,
+// `api_state` of a repair dock
+export enum RepairDockState {
+  /** Not unlocked yet */
+  Locked = -1,
+  Empty = 0,
+  Repairing = 1,
+}
+
+// `api_state` of a construction dock
+export enum ConstructionDockState {
+  /** Not unlocked yet */
+  Locked = -1,
+  Empty = 0,
+  Building = 2,
+  /** Built, waiting to be collected */
+  Completed = 3,
+}
+
+// `api_state` of a quest
+export enum QuestState {
+  Unselected = 1,
+  InProgress = 2,
+  Completed = 3,
+}
+
+// `api_progress_flag` of a quest: the coarse progress the game reports on top
+// of `QuestState`, for quests whose exact counter it doesn't expose
+export enum QuestProgressFlag {
+  /** Under 50% */
+  None = 0,
+  /** 50% or more */
+  Half = 1,
+  /** 80% or more */
+  Most = 2,
+}
+
+// `api_action_kind` of a land base: what its squadrons are ordered to do
+export enum AirbaseActionKind {
+  Standby = 0,
+  Sortie = 1,
+  Defense = 2,
+  Retreat = 3,
+  Rest = 4,
+}
+
+const AIRBASE_ACTION_KINDS = [
+  AirbaseActionKind.Standby,
+  AirbaseActionKind.Sortie,
+  AirbaseActionKind.Defense,
+  AirbaseActionKind.Retreat,
+  AirbaseActionKind.Rest,
 ]
 
-export const LBAC_STATUS_NAMES = ['Standby', 'Sortie', 'Defense', 'Retreat', 'Rest']
+// the game only ever sends the kinds above, but the payloads are optional and
+// partial in places, so narrow before indexing anything by the action kind
+export const toAirbaseActionKind = (value: unknown): AirbaseActionKind =>
+  AIRBASE_ACTION_KINDS.find((kind) => kind === value) ?? AirbaseActionKind.Standby
 
-export const LBAC_STATUS_AVATAR_COLOR = [
-  shipAvatarColor.WHITE,
-  shipAvatarColor.RED,
-  shipAvatarColor.ORANGE,
-  shipAvatarColor.BLUE,
-  shipAvatarColor.GREEN,
-]
+// A land base only takes part in a battle under these orders
+export const AIRBASE_ACTING_KINDS = [AirbaseActionKind.Sortie, AirbaseActionKind.Defense]
+
+// `api_state` of a squadron slot on a land base
+export enum PlaneState {
+  /** No plane assigned */
+  Empty = 0,
+  Ready = 1,
+  /** Being moved to another base */
+  Relocating = 2,
+}
+
+// `api_cond` of a squadron slot: its fatigue. Some responses send 0 for a slot
+// that is in fact rested, so treat anything below `Tired` as `Normal`.
+export enum PlaneCond {
+  Normal = 1,
+  Tired = 2,
+  Fatigued = 3,
+}
+
+export const LBAC_INTENTS: Record<AirbaseActionKind, Intent> = {
+  [AirbaseActionKind.Standby]: Intent.NONE,
+  [AirbaseActionKind.Sortie]: Intent.DANGER,
+  [AirbaseActionKind.Defense]: Intent.WARNING,
+  [AirbaseActionKind.Retreat]: Intent.PRIMARY,
+  [AirbaseActionKind.Rest]: Intent.SUCCESS,
+}
+
+export const LBAC_STATUS_NAMES: Record<AirbaseActionKind, string> = {
+  [AirbaseActionKind.Standby]: 'Standby',
+  [AirbaseActionKind.Sortie]: 'Sortie',
+  [AirbaseActionKind.Defense]: 'Defense',
+  [AirbaseActionKind.Retreat]: 'Retreat',
+  [AirbaseActionKind.Rest]: 'Rest',
+}
+
+export const LBAC_STATUS_AVATAR_COLOR: Record<AirbaseActionKind, string> = {
+  [AirbaseActionKind.Standby]: shipAvatarColor.WHITE,
+  [AirbaseActionKind.Sortie]: shipAvatarColor.RED,
+  [AirbaseActionKind.Defense]: shipAvatarColor.ORANGE,
+  [AirbaseActionKind.Retreat]: shipAvatarColor.BLUE,
+  [AirbaseActionKind.Rest]: shipAvatarColor.GREEN,
+}

--- a/views/utils/selectors/aggregate.ts
+++ b/views/utils/selectors/aggregate.ts
@@ -1,5 +1,6 @@
 import memoize from 'fast-memoize'
 import { createSelector } from 'reselect'
+import { DeckState } from 'views/utils/game-utils'
 
 import type { EquipDataWithOnslot, ShipData } from './base'
 
@@ -18,28 +19,32 @@ function getDeckState(
   inBattle: unknown,
   inExpedition: unknown,
   inRepairShipsId: number[] | undefined,
-): number {
-  let state = 0
-  if (inBattle) state = Math.max(state, 5)
-  if (inExpedition) state = Math.max(state, 4)
+): DeckState {
+  let state = DeckState.Ready
+  // a fleet keeps the most severe state that applies to it
+  const raiseTo = (candidate: DeckState) => {
+    if (candidate > state) state = candidate
+  }
+  if (inBattle) raiseTo(DeckState.Sortie)
+  if (inExpedition) raiseTo(DeckState.Expedition)
   shipsData?.forEach((pair) => {
     if (!pair) return
     const [ship, $ship] = pair
     if (!ship || !$ship) return
     // Cond < 20 or medium damage
     if ((ship.api_cond ?? 100) < 20 || (ship.api_nowhp ?? 1) / (ship.api_maxhp ?? 1) < 0.25)
-      state = Math.max(state, 2)
+      raiseTo(DeckState.Danger)
     // Cond < 40 or heavy damage
     else if ((ship.api_cond ?? 100) < 40 || (ship.api_nowhp ?? 1) / (ship.api_maxhp ?? 1) < 0.5)
-      state = Math.max(state, 1)
+      raiseTo(DeckState.Warning)
     // Not supplied
     if (
       (ship.api_fuel ?? 0) / ($ship.api_fuel_max ?? 1) < 0.99 ||
       (ship.api_bull ?? 0) / ($ship.api_bull_max ?? 1) < 0.99
     )
-      state = Math.max(state, 1)
+      raiseTo(DeckState.Warning)
     // Repairing
-    if (inRepairShipsId?.includes(ship.api_id)) state = Math.max(state, 3)
+    if (inRepairShipsId?.includes(ship.api_id)) raiseTo(DeckState.Repairing)
   })
   return state
 }

--- a/views/utils/selectors/fleet.ts
+++ b/views/utils/selectors/fleet.ts
@@ -4,6 +4,7 @@ import type { RootState } from 'views/redux/reducer-factory'
 import memoize from 'fast-memoize'
 import { get, map } from 'lodash'
 import { createSelector } from 'reselect'
+import { RepairDockState } from 'views/utils/game-utils'
 
 import { arrayResultWrapper, repairsSelector, sortieStatusSelector } from './base'
 
@@ -13,7 +14,7 @@ export const inRepairShipsIdSelector = arrayResultWrapper(
   createSelector(repairsSelector, (repairs: RepairData[] | undefined) => {
     if (!repairs) return
     return map(
-      repairs.filter((repair) => repair.api_state == 1),
+      repairs.filter((repair) => repair.api_state === RepairDockState.Repairing),
       'api_ship_id',
     )
   }),
@@ -68,6 +69,9 @@ export const fleetExpeditionSelectorFactory = memoize((fleetId: number) =>
 export const shipRepairDockSelectorFactory = memoize((shipId: number) =>
   createSelector(repairsSelector, (repairs) => {
     if (repairs == null) return
-    return repairs.find(({ api_state, api_ship_id }) => api_state == 1 && api_ship_id == shipId)
+    return repairs.find(
+      ({ api_state, api_ship_id }) =>
+        api_state === RepairDockState.Repairing && api_ship_id === shipId,
+    )
   }),
 )


### PR DESCRIPTION
## Problem

Fleet, dock, quest and land base states travelled through the code as bare numbers, compared against magic literals in components, reducers, selectors and services — `![3, 4, 5].includes(fleetState)`, `dock.api_state === -1`, `api_state === 3`, `![1, 2].includes(api_action_kind)`, `api_state[equipIdx] === 2`, and so on. Nothing said what those numbers meant, and the intent tables were positional arrays indexed by them.

## Change

One enum per API state field, all next to the constants they serve in `views/utils/game-utils.ts`, applied at every site that read the raw number:

| Enum | Field | Members |
| --- | --- | --- |
| `DeckState` | fleet state from `getDeckState` | `Ready` `Warning` `Danger` `Repairing` `Expedition` `Sortie` |
| `RepairDockState` | ndock `api_state` | `Locked -1` `Empty 0` `Repairing 1` |
| `ConstructionDockState` | kdock `api_state` | `Locked -1` `Empty 0` `Building 2` `Completed 3` |
| `QuestState` | quest `api_state` | `Unselected 1` `InProgress 2` `Completed 3` |
| `QuestProgressFlag` | `api_progress_flag` | `None 0` `Half 1` `Most 2` |
| `AirbaseActionKind` | `api_action_kind` | `Standby` `Sortie` `Defense` `Retreat` `Rest` |
| `PlaneState` / `PlaneCond` | squadron slot `api_state` / `api_cond` | `Empty/Ready/Relocating`, `Normal/Tired/Fatigued` |

Values and order are unchanged from what the game sends, since plugins read them.

Along the way:

- `UNAVAILABLE_DECK_STATES` replaces the two hardcoded `[3, 4, 5]` "this fleet can't sortie" filters in `event-sortie-check` and `sortie-unused-slot-check`, and `AIRBASE_ACTING_KINDS` replaces `![1, 2].includes(...)`.
- `getDeckState` keeps the most severe state via a named `raiseTo` helper instead of repeated `Math.max`.
- `FLEET_INTENTS`, `LBAC_INTENTS`, `LBAC_STATUS_NAMES` and `LBAC_STATUS_AVATAR_COLOR` are records keyed by their enum rather than positional arrays.
- `toAirbaseActionKind` narrows the optional/partial payload field, which removes both `LBAC_INTENTS[api_action_kind] as Intent` casts.

`QuestProgressFlag` carries the `Flag` suffix because `task-panel.tsx` already has a styled component named `QuestProgress`.

Not converted, deliberately: quest `api_category` (a taxonomy, not a state, and several values share a color), ship morale thresholds in `getCondStyle` (ranges, not discrete states), and raw numbers inside test fixtures and reducer payloads, which mirror the wire format.

No behaviour change. Typecheck, ESLint over `views` + `lib`, and the full Jest suite (231 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
