### PR TITLE
fix(main): open game popups detached to stop renderer crashes

### DIFF
--- a/lib/webcontent-utils.ts
+++ b/lib/webcontent-utils.ts
@@ -18,25 +18,42 @@ export function stopFileNavigate(id: number) {
   })
 }
 
+// Popup URLs reach these logs, and the flows that open them (payment, login) carry tokens
+// in the query string. Keep origin + path, which is all the diagnostics need, and drop the
+// query and fragment.
+const redactUrl = (url: string) => {
+  try {
+    const { origin, pathname } = new URL(url)
+    return `${origin}${pathname}`
+  } catch (_e) {
+    return '(unparseable url)'
+  }
+}
+
 // Diagnostics for windows the game page opens itself (`window.open`, e.g. the DMM charge
 // page). poi has no other visibility into them, so when one dies the only trace is an
 // unrelated-looking error from whoever touches the dead frame next — which is exactly how
 // the crash below presented. Log the popup's URL and the renderer exit reason.
 function watchGuestPopup(win: BrowserWindow, url: string) {
   const { webContents: popupContents } = win
-  log('webview popup created', url, 'osPid', popupContents.getOSProcessId())
+  log('webview popup created', redactUrl(url), 'osPid', popupContents.getOSProcessId())
 
   popupContents.addListener('render-process-gone', (_event, details) => {
-    warn('webview popup renderer gone', popupContents.getURL() || url, details)
+    warn('webview popup renderer gone', redactUrl(popupContents.getURL() || url), details)
   })
   popupContents.addListener(
     'did-fail-load',
     (_event, errorCode, errorDescription, validatedURL) => {
-      warn('webview popup failed to load', validatedURL || url, errorCode, errorDescription)
+      warn(
+        'webview popup failed to load',
+        redactUrl(validatedURL || url),
+        errorCode,
+        errorDescription,
+      )
     },
   )
   popupContents.addListener('unresponsive', () => {
-    warn('webview popup unresponsive', popupContents.getURL() || url)
+    warn('webview popup unresponsive', redactUrl(popupContents.getURL() || url))
   })
 }
 

--- a/lib/webcontent-utils.ts
+++ b/lib/webcontent-utils.ts
@@ -1,4 +1,4 @@
-import type { BrowserWindowConstructorOptions } from 'electron'
+import type { BrowserWindowConstructorOptions, WebContents } from 'electron'
 
 import * as electronRemote from '@electron/remote/main'
 import { BrowserWindow, webContents, shell, webFrameMain } from 'electron'
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import os from 'os'
 
 import config from './config'
-import { warn } from './utils'
+import { log, warn } from './utils'
 
 const isModernDarwin = process.platform === 'darwin' && Number(os.release().split('.')[0]) >= 17
 
@@ -15,6 +15,75 @@ export function stopFileNavigate(id: number) {
     if (url.startsWith('file')) {
       e.preventDefault()
     }
+  })
+}
+
+// Diagnostics for windows the game page opens itself (`window.open`, e.g. the DMM charge
+// page). poi has no other visibility into them, so when one dies the only trace is an
+// unrelated-looking error from whoever touches the dead frame next — which is exactly how
+// the crash below presented. Log the popup's URL and the renderer exit reason.
+function watchGuestPopup(win: BrowserWindow, url: string) {
+  const { webContents: popupContents } = win
+  log('webview popup created', url, 'osPid', popupContents.getOSProcessId())
+
+  popupContents.addListener('render-process-gone', (_event, details) => {
+    warn('webview popup renderer gone', popupContents.getURL() || url, details)
+  })
+  popupContents.addListener(
+    'did-fail-load',
+    (_event, errorCode, errorDescription, validatedURL) => {
+      warn('webview popup failed to load', validatedURL || url, errorCode, errorDescription)
+    },
+  )
+  popupContents.addListener('unresponsive', () => {
+    warn('webview popup unresponsive', popupContents.getURL() || url)
+  })
+}
+
+const parseWindowFeature = (features: string, key: string) => {
+  const matched = new RegExp(`(?:^|,)\\s*${key}\\s*=\\s*(\\d+)`).exec(features)
+  return matched ? Number(matched[1]) : undefined
+}
+
+// The game webview runs with `disablewebsecurity` (see views/kan-game-wrapper.tsx), which
+// the game page's own iframe traversal depends on. A popup opened from that page keeps an
+// opener relationship with it and so ends up in the same renderer process; loading an
+// ordinary secure page there — the DMM point-charge flow is the one that surfaced this —
+// crashes that renderer outright (STATUS_BREAKPOINT, no log output), taking the game down
+// with it. Opening the popup ourselves drops the opener link, so the page gets a clean
+// process with web security left on.
+function openGuestPopupDetached(url: string, features: string) {
+  const win = new BrowserWindow({
+    width: parseWindowFeature(features, 'width') ?? 800,
+    height: parseWindowFeature(features, 'height') ?? 600,
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+    },
+  })
+  watchGuestPopup(win, url)
+  win.loadURL(url)
+}
+
+function handleGuestPopups(wc: WebContents) {
+  wc.setWindowOpenHandler(({ url, features }) => {
+    // Only http(s) can be re-opened detached. Anything else (`about:blank` popups the page
+    // then scripts, in particular) still needs the opener link, so leave it alone rather
+    // than breaking game flows that rely on it.
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      openGuestPopupDetached(url, features)
+      return { action: 'deny' }
+    }
+    return { action: 'allow' }
+  })
+
+  // Popups still created by Chromium (the non-http case above).
+  wc.addListener('did-create-window', (win, { url }) => {
+    watchGuestPopup(win, url)
   })
 }
 
@@ -27,6 +96,8 @@ export function handleWebviewPreloadHack(id: number) {
   }
 
   webContent.addListener('did-attach-webview', (event, wc) => {
+    handleGuestPopups(wc)
+
     wc.addListener(
       'did-frame-navigate',
       async (


### PR DESCRIPTION
## Problem

Opening the DMM point-charge page from the game killed the renderer: `render-process-gone` with `reason: "crashed"` and exit code `-2147483645` (`0x80000003`, `STATUS_BREAKPOINT`), twice per attempt, taking the game down with it.

The crash produced **no diagnostic output whatsoever** — no `CHECK`/`FATAL` line in the Chromium log (`--enable-logging=file --log-level=0`), and nothing on stderr either. What surfaced instead was a misleading error from elsewhere in the app, `Error sending from webFrameMain: Render frame was disposed before WebFrameMain could be accessed`, which is just whatever touched the dead frame next.

## Cause

`disablewebsecurity` on the game webview. A `window.open` popup keeps an opener relationship with the game page and so ends up in that same renderer process; loading an ordinary secure page into a process whose web security is disabled crashes it.

## Fix

Give the webview guest a `setWindowOpenHandler` that denies http(s) popups and re-opens them in a detached `BrowserWindow` (`webSecurity: true`, `sandbox: true`, no node integration). No opener link means the page can no longer land in the game's relaxed process.

`about:blank` popups still take the normal allow path — those get scripted by the opener, and detaching them would break game flows that depend on it.

This also adds logging for windows the game opens itself. poi previously had no visibility into them at all, which is the reason the crash presented as an unrelated error in the first place.

## Verification

Confirmed against the real charge flow.

Root-caused by bisecting a standalone Electron harness that reproduces poi's structure — a `<webview>` carrying the same attributes, loading the game page, with the charge page opened via `window.open` from it:

- baseline (plain webview + `allowpopups`) — no crash
- `+ disablewebsecurity` — **crash**
- `+ nodeintegrationinsubframes` / `sandbox=no` / UA rewrite / poi's command-line switches — no crash
- same URL in a top-level window with no opener — no crash

Ruled out along the way and not worth re-testing: `--disable-site-isolation-trials`, devtools extensions, the proxy, Sentry, plugins, `@electron/remote`, and inherited `webPreferences` (Electron's `makeWebPreferences` does not inherit `preload` or `disablewebsecurity` into child windows).

## Note for reviewers

`window.open` now returns `null` to the game page for http(s) URLs, and the popup has no `window.opener`. The charge flow does not care — its `back_url` self-closes — but any other in-game popup that reads the returned handle or calls back into its opener would be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
