### PR TITLE
chore(deps): bump poi-lib-battle to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "pirates": "^4.0.7",
         "poi-asset-contributor-data": "^1.2.1",
         "poi-asset-themes": "^4.6.0",
-        "poi-lib-battle": "^3.0.0",
+        "poi-lib-battle": "^3.2.0",
         "polished": "^4.3.1",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -21730,9 +21730,9 @@
       "integrity": "sha512-rdpIfAS7cuj0SkzMA2sqFbamm+DbTfPloLhyq4ZVxqmnknxqDTGjBdsirVBHagjdxbt3Brtp6UW9lfkxznlhnA=="
     },
     "node_modules/poi-lib-battle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/poi-lib-battle/-/poi-lib-battle-3.0.0.tgz",
-      "integrity": "sha512-j7APczW82yAlJai6LsWV+qrzBRxy62Ot0ul0+ey0JPFLqlWSZeZFwM1f1kir5TfXbiDbPtTWIjfLQ8jxdpxqjQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/poi-lib-battle/-/poi-lib-battle-3.2.0.tgz",
+      "integrity": "sha512-CRUNvFDeSjRWhrcq93qJtrsb1QGThEJU5ic6cOgHzlix8dBrq/9w+uCgFyuzv+DWsUsjloIiQL/HGyQp2lExYQ==",
       "license": "MIT"
     },
     "node_modules/polished": {
@@ -41039,9 +41039,9 @@
       "integrity": "sha512-rdpIfAS7cuj0SkzMA2sqFbamm+DbTfPloLhyq4ZVxqmnknxqDTGjBdsirVBHagjdxbt3Brtp6UW9lfkxznlhnA=="
     },
     "poi-lib-battle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/poi-lib-battle/-/poi-lib-battle-3.0.0.tgz",
-      "integrity": "sha512-j7APczW82yAlJai6LsWV+qrzBRxy62Ot0ul0+ey0JPFLqlWSZeZFwM1f1kir5TfXbiDbPtTWIjfLQ8jxdpxqjQ=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/poi-lib-battle/-/poi-lib-battle-3.2.0.tgz",
+      "integrity": "sha512-CRUNvFDeSjRWhrcq93qJtrsb1QGThEJU5ic6cOgHzlix8dBrq/9w+uCgFyuzv+DWsUsjloIiQL/HGyQp2lExYQ=="
     },
     "polished": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "pirates": "^4.0.7",
     "poi-asset-contributor-data": "^1.2.1",
     "poi-asset-themes": "^4.6.0",
-    "poi-lib-battle": "^3.0.0",
+    "poi-lib-battle": "^3.2.0",
     "polished": "^4.3.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/views/redux/battle.ts
+++ b/views/redux/battle.ts
@@ -1,3 +1,5 @@
+import type { RawFleetShip } from 'poi-lib-battle/packet'
+
 import { createAction, isAnyOf, type UnknownAction } from '@reduxjs/toolkit'
 import { cloneDeep, get } from 'lodash'
 import { Models, Simulator } from 'poi-lib-battle'
@@ -70,10 +72,7 @@ function getItem(itemId: number, store: Record<string, unknown>): Record<string,
   return item
 }
 
-function getShip(
-  shipId: number,
-  store: Record<string, unknown>,
-): (Record<string, unknown> & { poi_slot: unknown[]; poi_slot_ex: unknown }) | null {
+function getShip(shipId: number, store: Record<string, unknown>): RawFleetShip | null {
   const _ship = get(store, `info.ships.${shipId}`)
   if (!isRecord(_ship)) return null
   const master = get(store, `const.$ships.${_ship['api_ship_id']}`)
@@ -93,10 +92,17 @@ function getShip(
   delete ship['api_slot']
   delete ship['api_slot_ex']
   delete ship['api_yomi']
-  return ship
+  // The store is untyped here, so TypeScript cannot see that this is a real
+  // ship record merged with its master data. Assert once, at the single point
+  // where store data becomes a fleet ship, and keep callers strongly typed.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return ship as unknown as RawFleetShip
 }
 
-function getFleet(deckId: number, store: Record<string, unknown>): unknown[] | null {
+function getFleet(
+  deckId: number,
+  store: Record<string, unknown>,
+): Array<RawFleetShip | null> | null {
   const deckRaw = get(store, `info.fleets.${deckId - 1}`)
   if (!isRecord(deckRaw)) return null
   const ships = deckRaw['api_ship']


### PR DESCRIPTION
## Summary

`poi-lib-battle` was pinned at 3.0.0 in the lockfile. 3.1.0 and 3.2.0 shipped on 2026-08-09, covering the same game update as the recent kcsapi release — `api_e_maxhps`/`api_e_nowhps` widen to `Array<number | string>` in both. The `^3.0.0` range already permitted the upgrade; only the lock held it back.

## Why there is a source change

3.2.0 replaced the `unknown` placeholders in the public types with real ones. `Fleet.main` and `Fleet.escort` now expect `Array<RawFleetShip | null>` instead of `unknown[]`, which surfaces two type errors in `views/redux/battle.ts`.

That file builds fleet ships out of the untyped store via lodash `get`, so `getShip`/`getFleet` now return the library's `RawFleetShip`. TypeScript cannot see that a record pulled from the store is a real ship record merged with its master data, and runtime-validating all 31 required fields of `APIGetMemberShip2Response` would be pointless — so there is a single assertion at that one boundary rather than one at each call site. Everything downstream stays strongly typed.

## Verification

Checked against the kcsapi version this branch pins (1.260604), not just the newer one on the other branch — the two upgrades are independent, and I confirmed every kcsapi module and named import that lib-battle 3.2.0 references already exists in 1.260604, so neither PR blocks the other.

- [x] `npm run typecheck`
- [x] `npx jest` — 30 suites, 231 tests, 26 snapshots pass
- [x] `npm run lint:js` on the changed file
- [ ] Confirm a real sortie still simulates correctly in the app

The last box is worth a maintainer's eye: the type change is compile-time only, but `battle.ts` feeds the simulator and the tests here do not cover a live battle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
