### PR TITLE
feat(air-power): support 噴式戦闘機 in fighter power

### DIFF
--- a/views/utils/__tests__/game-utils.spec.ts
+++ b/views/utils/__tests__/game-utils.spec.ts
@@ -1,0 +1,82 @@
+import type { APIMstSlotitem } from 'kcsapi/api_start2/getData/response'
+import type { Equip } from 'views/redux/info/equips'
+
+import { equipIsAircraft, getTyku } from '../game-utils'
+
+const spec = it
+
+const data: { api_mst_slotitem: APIMstSlotitem[] } = require('./fixtures/api_start2.json')
+
+const $equip = (mstId: number): APIMstSlotitem => {
+  const found = data.api_mst_slotitem.find(({ api_id }) => api_id === mstId)
+  if (!found) throw new Error(`slotitem ${mstId} missing from api_start2 fixture`)
+  return found
+}
+
+// 548: 震電改三(試製 噴式震電), the first 噴式戦闘機 (api_type[2] === 56)
+const JET_FIGHTER = 548
+// 20: 零式艦戦52型, a plain 艦上戦闘機 with the same proficiency bonus table
+const CARRIER_FIGHTER = 20
+
+const equip = (mstId: number, { alv = 0, level = 0 } = {}): Equip =>
+  ({ api_id: 1, api_slotitem_id: mstId, api_locked: 0, api_level: level, api_alv: alv }) as Equip
+
+/** One ship carrying one plane, in the shape `getTyku` expects */
+const oneSlot = (mstId: number, onslot: number, opts?: { alv?: number; level?: number }) => [
+  [[equip(mstId, opts), $equip(mstId), onslot] as [Equip, APIMstSlotitem, number]],
+]
+
+describe('getTyku', () => {
+  spec('噴式戦闘機 counts towards fighter power', () => {
+    // sqrt(18) * 17 = 72.13; `max` adds the top of the alv 0 internal exp range
+    expect(getTyku(oneSlot(JET_FIGHTER, 18))).toEqual({ basic: 72, min: 72, max: 73 })
+  })
+
+  spec('噴式戦闘機 gets the fighter proficiency bonus', () => {
+    // +22 type bonus at alv 7, plus sqrt(internal exp / 10)
+    expect(getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }))).toEqual({
+      basic: 72,
+      min: 97,
+      max: 97,
+    })
+  })
+
+  spec('噴式戦闘機 improvement adds 0.2 AA per star, like other fighters', () => {
+    const jet = getTyku(oneSlot(JET_FIGHTER, 18, { level: 10 }))
+    // sqrt(18) * (17 + 10 * 0.2) = 80.61
+    expect(jet).toEqual({ basic: 72, min: 80, max: 81 })
+  })
+
+  spec('噴式戦闘機 has no 局地戦闘機 interception bonus on a land base', () => {
+    // api_houk / api_houm are plain evasion / accuracy here, so air defense
+    // (landbaseStatus 2) is worth the same as a sortie
+    expect(getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }), 2)).toEqual(
+      getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }), 1),
+    )
+  })
+
+  spec('噴式戦闘機 matches a carrier fighter of the same AA stat', () => {
+    // 零式艦戦52型 has AA 12 against the jet's 17, so compare the proficiency
+    // bonus rather than the raw values
+    const jet = getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }))
+    const fighter = getTyku(oneSlot(CARRIER_FIGHTER, 18, { alv: 7 }))
+    const jetBase = getTyku(oneSlot(JET_FIGHTER, 18))
+    const fighterBase = getTyku(oneSlot(CARRIER_FIGHTER, 18))
+    expect(jet.min - jetBase.min).toBe(fighter.min - fighterBase.min)
+  })
+})
+
+describe('equipIsAircraft', () => {
+  spec('recognises 噴式戦闘機 by master data', () => {
+    expect(equipIsAircraft($equip(JET_FIGHTER))).toBe(true)
+  })
+
+  spec('recognises the newer plane icons by id', () => {
+    // 57: 試製 震電(局地戦闘機), 59: Ho229, 60: 震電改三
+    expect([57, 58, 59, 60].map(equipIsAircraft)).toEqual([true, true, true, true])
+  })
+
+  spec('does not treat a gun icon as an aircraft', () => {
+    expect(equipIsAircraft(1)).toBe(false)
+  })
+})

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -18,7 +18,9 @@ const aircraftLevelBonus: Record<number, number[]> = {
   45: [0, 0, 2, 5, 9, 14, 14, 22, 22],
   47: [0, 0, 0, 0, 0, 0, 0, 0, 0],
   48: [0, 0, 2, 5, 9, 14, 14, 22, 22],
-  56: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+  // 56: 噴式戦闘機. It is a fighter, so it takes the same proficiency air power
+  // bonus as 艦戦/水戦/局戦 rather than the bomber-like zeroes of the other jets.
+  56: [0, 0, 2, 5, 9, 14, 14, 22, 22],
   57: [0, 0, 0, 0, 0, 0, 0, 0, 0],
   58: [0, 0, 0, 0, 0, 0, 0, 0, 0],
 }
@@ -401,13 +403,16 @@ export function getHpStyle(percent: number): MaterialIntent {
 
 export function equipIsAircraft(equip: APIMstSlotitem | number): boolean {
   if (typeof equip === 'number') {
+    // icon id (`api_type[3]`); 56-60 covers the later fighter/jet icons, up to
+    // 60 (震電改三, the first 噴式戦闘機)
     return (
       equip != null &&
       (between(equip, 6, 10) ||
         between(equip, 21, 22) ||
         between(equip, 37, 40) ||
         between(equip, 43, 51) ||
-        [33, 56].includes(equip))
+        between(equip, 56, 60) ||
+        equip === 33)
     )
   } else {
     const id = equip?.api_type?.[2]
@@ -452,7 +457,9 @@ export function getTyku(
       }
       const levelFactor = $equip.api_tyku > 3 ? ($equip.api_baku > 0 ? 0.25 : 0.2) : 0
       if (
-        [6, 7, 45, 47, 57].includes($equip.api_type[2]) ||
+        // 56 (噴式戦闘機) uses the plain fighter formula on both fleets and land
+        // bases: unlike 局地戦闘機 it has no 迎撃/対爆 stats, so no landbase bonus.
+        [6, 7, 45, 47, 56, 57].includes($equip.api_type[2]) ||
         ([26].includes($equip.api_type[2]) && $equip.api_tyku > 0)
       ) {
         tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)


### PR DESCRIPTION
## Summary

`震電改三(試製 噴式震電)` (mst id 548) is the game''s first `噴式戦闘機` — equipment type `api_type[2] === 56`, a category `getTyku` never handled. The plane therefore contributed **0 fighter power** on both fleets and land bases.

## Changes

- **`getTyku`**: added `56` to the plain fighter branch `[6, 7, 45, 47, 57]`, so it uses `sqrt(onslot) × (AA + ★ × 0.2)`. It deliberately does *not* go into the `48` (`局地戦闘機`) branch — despite being land-base usable (radius 2), its `api_houm`/`api_houk` are ordinary accuracy/evasion rather than `対爆`/`迎撃`, so there is no air-defense bonus.
- **`aircraftLevelBonus`**: type 56 goes from all-zeroes to the fighter proficiency table `[0, 0, 2, 5, 9, 14, 14, 22, 22]`, cross-checked against KC3Kai''s `airPowerTypeBonuses`, which lists `56` alongside `6`/`45`/`48`. The other jet types (57/58) correctly stay at zero.
- **`equipIsAircraft`**: the numeric (icon id) overload had gone stale — it covered icons up to 56 but missed `57` (`試製 震電`), `58`, `59` (`Ho229`) and the new `60`. Widened to `56-60`. Only plugins reach that overload; the master-data path already covered type 56.

## Not changed

- Equipability is fully data-driven through `api_mst_equip_ship`, so the five carriers that can carry it (`翔鶴改二甲`, `瑞鶴改二甲`, `加賀改二護`, `Victorious改`, `飛龍改三`) already work without code changes.
- `★` improvement: poi applies its generic `+0.2 AA/star` to type 56 where KC3 gives jets none. The item cannot currently be improved, so this is moot today, and 0.2 is the likely value if that changes.

## Test plan

- New `views/utils/__tests__/game-utils.spec.ts`, driven by the real `api_start2` fixture (which already contains item 548): fighter power, proficiency bonus, improvement, land-base parity, and the icon-id checks.
- `npx jest views/utils/__tests__` — 29 passed
- `npm run typecheck` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)