### PR TITLE
feat(combat): sync OASW, AACI and sp-attack with current game data

### DIFF
--- a/views/utils/combat/__tests__/aaci.spec.ts
+++ b/views/utils/combat/__tests__/aaci.spec.ts
@@ -2,7 +2,7 @@ import { every, isFinite, each, isArray, isString, isBoolean } from 'lodash'
 
 import type { GameEquip, GameShip } from '../aaci'
 
-import { AACITable, getShipAACIs } from '../aaci'
+import { AACITable, getShipAACIs, getShipAvailableAACIs } from '../aaci'
 const {
   ship,
   equips,
@@ -33,5 +33,58 @@ describe('AACI entry check', () => {
 
   it('sample ship should match aaci test', () => {
     expect(getShipAACIs(ship, equips).length > 0).toBe(true)
+  })
+})
+
+describe('三十二駆改二 AACI (types 49~52)', () => {
+  // 10cm連装高角砲改 (553) ×2 + 94式高射装置 (121) satisfies type 52
+  const mount100mmKai: GameEquip = { ...equips[0], api_slotitem_id: 553 }
+  const type94AAFD: GameEquip = { ...equips[0], api_slotitem_id: 121 }
+  const type52Setup = [mount100mmKai, mount100mmKai, type94AAFD]
+
+  // 玉波改二 (1033) is an already-covered member, used here as the control
+  it.each([
+    ['玉波改二', 1033],
+    ['涼波改二', 1034],
+    ['涼波改二補', 745],
+  ])('%s is eligible for type 52', (_name, shipId) => {
+    expect(getShipAvailableAACIs({ ...ship, api_ship_id: shipId }, type52Setup)).toContain(52)
+  })
+
+  it('does not extend to an unrelated 夕雲型改二', () => {
+    // 長波改二補 (743) is not part of 三十二駆改二
+    expect(getShipAvailableAACIs({ ...ship, api_ship_id: 743 }, type52Setup)).not.toContain(52)
+  })
+})
+
+describe('AACI type 53 (飛龍改三)', () => {
+  // ctype 25 = 飛龍型; overriding it keeps the Akizuki-class entries of the
+  // fixture ship from also matching
+  const hiryuuK3: GameShip = { ...ship, api_ship_id: 1031, api_stype: 11, api_ctype: 25 }
+  // icon 16 = 高角砲
+  const highAngleMount = (tyku: number): GameEquip => ({
+    ...equips[0],
+    api_slotitem_id: 122,
+    api_type: [1, 1, 1, 16, 0],
+    api_tyku: tyku,
+  })
+  // fixture equip 0 is 13号対空電探改 (対空 4)
+  const aaRadar = equips[0]
+
+  it('triggers with a 素対空9 特殊高角砲 and an 素対空4 対空電探', () => {
+    expect(getShipAACIs(hiryuuK3, [highAngleMount(9), aaRadar])).toContain(53)
+  })
+
+  it('does not trigger below the equipment thresholds', () => {
+    expect(getShipAvailableAACIs(hiryuuK3, [highAngleMount(8), aaRadar])).not.toContain(53)
+    expect(
+      getShipAvailableAACIs(hiryuuK3, [highAngleMount(9), { ...aaRadar, api_tyku: 3 }]),
+    ).not.toContain(53)
+  })
+
+  it('is exclusive to 飛龍改三', () => {
+    expect(
+      getShipAvailableAACIs({ ...hiryuuK3, api_ship_id: 1030 }, [highAngleMount(9), aaRadar]),
+    ).not.toContain(53)
   })
 })

--- a/views/utils/combat/__tests__/oasw.spec.ts
+++ b/views/utils/combat/__tests__/oasw.spec.ts
@@ -72,6 +72,20 @@ describe('isOASW', () => {
     expect(isOASW(taiyouKai, [torpedoBomber(0)])).toBe(false)
   })
 
+  it('triggers unconditionally for Visby and Visby改', () => {
+    expect(isOASW({ ...baseShip, api_ship_id: 1062, api_taisen: [0, 0] }, [])).toBe(true)
+    expect(isOASW({ ...baseShip, api_ship_id: 1067, api_taisen: [0, 0] }, [])).toBe(true)
+  })
+
+  it('triggers unconditionally for 日枝丸/改 despite being a 潜水母艦', () => {
+    // stype 20 is not covered by any of the ship-type branches
+    const hiedaMaru: GameShip = { ...baseShip, api_stype: 20, api_taisen: [0, 0] }
+    expect(isOASW({ ...hiedaMaru, api_ship_id: 1065 }, [])).toBe(true)
+    expect(isOASW({ ...hiedaMaru, api_ship_id: 1070 }, [])).toBe(true)
+    // a different 潜水母艦 still does not
+    expect(isOASW({ ...hiedaMaru, api_ship_id: 944, api_taisen: [100, 100] }, [sonar])).toBe(false)
+  })
+
   it('deprecated import path re-exports the same function', () => {
     expect(isOASWCompat).toBe(isOASW)
   })

--- a/views/utils/combat/__tests__/sp-attack.spec.ts
+++ b/views/utils/combat/__tests__/sp-attack.spec.ts
@@ -108,6 +108,23 @@ describe('isSpAttackAvailable', () => {
       expect(isSpAttackAvailable(fleet, { ...extra, spAttackCount: { 104: 2 } })).toBe(true)
       expect(isSpAttackAvailable(fleet, { ...extra, spAttackCount: { 104: 3 } })).toBe(false)
     })
+
+    // 大破未満 only: unlike the other special attacks, 中破 still triggers
+    it('still triggers when either ship is at medium damage', () => {
+      // fixture HP is 37/37; 18/37 is 中破 (>1/4, <=1/2)
+      const midDmgKongou: GameShip = { ...kongouK2C, api_nowhp: 18 }
+      const midDmgHiei: GameShip = { ...hieiK2C, api_nowhp: 18 }
+      expect(isSpAttackAvailable([midDmgKongou, hieiK2C, dd, dd, dd], extra)).toBe(true)
+      expect(isSpAttackAvailable([kongouK2C, midDmgHiei, dd, dd, dd], extra)).toBe(true)
+    })
+
+    it('does not trigger when either ship is at heavy damage', () => {
+      // 9/37 is 大破 (<=1/4)
+      const heavyDmgKongou: GameShip = { ...kongouK2C, api_nowhp: 9 }
+      const heavyDmgHiei: GameShip = { ...hieiK2C, api_nowhp: 9 }
+      expect(isSpAttackAvailable([heavyDmgKongou, hieiK2C, dd, dd, dd], extra)).toBe(false)
+      expect(isSpAttackAvailable([kongouK2C, heavyDmgHiei, dd, dd, dd], extra)).toBe(false)
+    })
   })
 
   it('handles short fleets without throwing', () => {

--- a/views/utils/combat/aaci.md
+++ b/views/utils/combat/aaci.md
@@ -8,7 +8,18 @@ The code was originally ported from KC3Kai commit a9edbe5. The wiki is the autho
 
 ## Last Validated
 
-2026-05-27. Fixed/modifier values for all types 1–52 match the wiki. Discrepancies were in ship eligibility and one equipment rule (type 27).
+2026-08-12. Fixed/modifier values for all types 1–53 match the wiki. Discrepancies were in ship eligibility and one equipment rule (type 27).
+
+## Added 2026-08-12
+
+**Type 53 — 飛龍改三 dedicated AACI**: 素対空9以上の特殊高角砲 + 素対空4以上の対空電探,
+固定 4, 変動 1.6. The wiki still marks the 変動ボーナス with `?`, so treat 1.6 as
+provisional and re-check on the next pass.
+
+**Types 49–52 — 涼波改二 (ID 1034) / 涼波改二補 (ID 745) added**: both count as 三十二駆改二,
+so they join 藤波/早波/浜波/玉波改二. The four entries now share one `isFubukiOr32ndDivisionK2`
+predicate and one `fubukiOr32ndDivisionK2Names` list (type 50 adds 秋月型 on top), so the next
+member only has to be added in one place.
 
 ## Fixes Applied (2026-05-27)
 

--- a/views/utils/combat/aaci/api.ts
+++ b/views/utils/combat/aaci/api.ts
@@ -1,5 +1,3 @@
-import { maxBy } from 'lodash'
-
 import type { GameEquip, GameShip } from '../types'
 import type { AACIEntry } from './types'
 
@@ -53,10 +51,24 @@ export const getShipAllAACIs = (ship: GameShip): number[] =>
     })
     .map((key) => Number(key))
 
+// Pick the id of the AACI that actually fires: highest 固定ボーナス, ties broken by
+// highest 変動ボーナス — the same ordering as sortAaciIds. Returns 0 for an empty list.
+// The modifier tie-break matters for ship-exclusive types that share a 固定ボーナス
+// with a generic type (e.g. 53 vs 8, both fixed 4).
+const bestAACIId = (aaciIds: number[]): number =>
+  aaciIds.reduce((best, id) => {
+    const candidate = AACITable[id]
+    const incumbent = AACITable[best]
+    if (!candidate) return best
+    if (!incumbent) return id
+    if (candidate.fixed !== incumbent.fixed) return candidate.fixed > incumbent.fixed ? id : best
+    return candidate.modifier > incumbent.modifier ? id : best
+  }, 0)
+
 // return the AACIs to trigger for a ship, it will be array due to exceptions
 export const getShipAACIs = (ship: GameShip, equips: GameEquip[]): number[] => {
   const AACIs = getShipAvailableAACIs(ship, equips)
-  const maxFixed = maxBy(AACIs, (id) => (AACITable[id] || {}).fixed || 0) || 0
+  const maxFixed = bestAACIId(AACIs)
   // Kinu kai 2 exception
   if (AACIs.includes(19)) {
     return [19, 20]

--- a/views/utils/combat/aaci/entries.ts
+++ b/views/utils/combat/aaci/entries.ts
@@ -11,6 +11,8 @@
    - https://github.com/andanteyk/ElectronicObserver/blob/master/ElectronicObserver/Other/Information/apilist.txt (as of Jan 1, 2019)
 
  */
+import type { GameShip } from '../types'
+
 import {
   hasAtLeast,
   hasSome,
@@ -40,6 +42,7 @@ import {
   isAtlantaOrKai,
   isBattleship,
   isBuiltinHighAngleMount,
+  isBuiltinHighAngleMountAA9,
   isCDMG,
   isFletcherClassOrKai,
   isFubukiK2,
@@ -83,6 +86,7 @@ import {
   isSatsukiK2,
   isShiratsuyuClassK2,
   isShirayukiK2,
+  isSuzunamiK2,
   isTamananiK2,
   isTatsutaK2,
   isTenryuuK2,
@@ -620,53 +624,51 @@ declareAACI({
   ),
 })
 
-// id 49: Fubuki Kai Ni / Shirayuki Kai Ni / Hatsuyuki Kai Ni / Fujinami Kai Ni / Hayanami Kai Ni / Hamanami Kai Ni / Tamanami Kai Ni
+// id 49~52 share the same 対象艦: 吹雪改二/改三/改三護(六式), 白雪改二, 初雪改二 and the
+// 三十二駆改二 (藤波/早波/浜波/玉波/涼波; 涼波改二補 counts as 涼波改二).
+const isFubukiOr32ndDivisionK2 = (ship: GameShip) =>
+  isFubukiK2(ship) ||
+  isFubukiK3(ship) ||
+  isFubukiK3Go(ship) ||
+  isShirayukiK2(ship) ||
+  isHatsuyukiK2(ship) ||
+  isFujinamiK2(ship) ||
+  isHayanamiK2(ship) ||
+  isHamanamiK2(ship) ||
+  isTamananiK2(ship) ||
+  isSuzunamiK2(ship)
+
+const fubukiOr32ndDivisionK2Names = [
+  '吹雪改二',
+  '白雪改二',
+  '初雪改二',
+  '藤波改二',
+  '早波改二',
+  '浜波改二',
+  '玉波改二',
+  '涼波改二',
+  '涼波改二補',
+]
+
+// id 49
 declareAACI({
-  name: ['藤波改二', '吹雪改二', '白雪改二', '初雪改二', '早波改二', '浜波改二', '玉波改二'],
+  name: fubukiOr32ndDivisionK2Names,
   id: 49,
   fixed: 5,
   modifier: 1.5,
-  shipValid: (ship) =>
-    isFubukiK2(ship) ||
-    isFubukiK3(ship) ||
-    isFubukiK3Go(ship) ||
-    isShirayukiK2(ship) ||
-    isHatsuyukiK2(ship) ||
-    isFujinamiK2(ship) ||
-    isHayanamiK2(ship) ||
-    isHamanamiK2(ship) ||
-    isTamananiK2(ship),
+  shipValid: isFubukiOr32ndDivisionK2,
   equipsValid: validAny(
     validAll(hasAtLeast(isBuiltinHighAngleMount, 2), hasSome(isAdvancedAARadar)),
   ),
 })
 
-// id 50: Fubuki Kai Ni / Shirayuki Kai Ni / Hatsuyuki Kai Ni / Fujinami Kai Ni / Hayanami Kai Ni / Hamanami Kai Ni / Tamanami Kai Ni / Akizuki Class
+// id 50: the same 対象艦 plus Akizuki Class
 declareAACI({
-  name: [
-    '吹雪改二',
-    '白雪改二',
-    '初雪改二',
-    '藤波改二',
-    '早波改二',
-    '浜波改二',
-    '玉波改二',
-    'Akizuki Class',
-  ],
+  name: [...fubukiOr32ndDivisionK2Names, 'Akizuki Class'],
   id: 50,
   fixed: 7,
   modifier: 1.5,
-  shipValid: (ship) =>
-    isFubukiK2(ship) ||
-    isFubukiK3(ship) ||
-    isFubukiK3Go(ship) ||
-    isShirayukiK2(ship) ||
-    isHatsuyukiK2(ship) ||
-    isFujinamiK2(ship) ||
-    isHayanamiK2(ship) ||
-    isHamanamiK2(ship) ||
-    isTamananiK2(ship) ||
-    isAkizukiClass(ship),
+  shipValid: (ship) => isFubukiOr32ndDivisionK2(ship) || isAkizukiClass(ship),
   equipsValid: validAny(
     validAll(
       hasAtLeast(is100mmTwinMountKaiOrAAFD, 2),
@@ -676,41 +678,34 @@ declareAACI({
   ),
 })
 
-// id 51~52: Fubuki Kai Ni / Shirayuki Kai Ni / Hatsuyuki Kai Ni / Fujinami Kai Ni / Hayanami Kai Ni / Hamanami Kai Ni / Tamanami Kai Ni
+// id 51~52
 declareAACI({
-  name: ['吹雪改二', '白雪改二', '初雪改二', '藤波改二', '早波改二', '浜波改二', '玉波改二'],
+  name: fubukiOr32ndDivisionK2Names,
   id: 51,
   fixed: 5,
   modifier: 1.35,
-  shipValid: (ship) =>
-    isFubukiK2(ship) ||
-    isFubukiK3(ship) ||
-    isFubukiK3Go(ship) ||
-    isShirayukiK2(ship) ||
-    isHatsuyukiK2(ship) ||
-    isFujinamiK2(ship) ||
-    isHayanamiK2(ship) ||
-    isHamanamiK2(ship) ||
-    isTamananiK2(ship),
+  shipValid: isFubukiOr32ndDivisionK2,
   equipsValid: validAny(
     validAll(hasSome(is100mmTwinMountKaiOrAAFD), hasSome(isAdvancedAARadar), hasSome(isAAGun)),
   ),
 })
 
 declareAACI({
-  name: ['吹雪改二', '白雪改二', '初雪改二', '藤波改二', '早波改二', '浜波改二', '玉波改二'],
+  name: fubukiOr32ndDivisionK2Names,
   id: 52,
   fixed: 4,
   modifier: 1.4,
-  shipValid: (ship) =>
-    isFubukiK2(ship) ||
-    isFubukiK3(ship) ||
-    isFubukiK3Go(ship) ||
-    isShirayukiK2(ship) ||
-    isHatsuyukiK2(ship) ||
-    isFujinamiK2(ship) ||
-    isHayanamiK2(ship) ||
-    isHamanamiK2(ship) ||
-    isTamananiK2(ship),
+  shipValid: isFubukiOr32ndDivisionK2,
   equipsValid: validAny(validAll(hasAtLeast(is100mmTwinMountKai, 2), hasSome(isType94AAFD))),
+})
+
+// id 53: Hiryuu Kai 3 (dedicated AACI)
+// NOTE: wikiwiki still marks the 変動ボーナス of this type with "?"; revisit once confirmed.
+declareAACI({
+  name: ['飛龍改三'],
+  id: 53,
+  fixed: 4,
+  modifier: 1.6,
+  shipValid: isHiryuuK3,
+  equipsValid: validAll(hasSome(isBuiltinHighAngleMountAA9), hasSome(isAdvancedAARadar)),
 })

--- a/views/utils/combat/equip-predicates.ts
+++ b/views/utils/combat/equip-predicates.ts
@@ -25,6 +25,9 @@ export const isAdvancedAARadar = (equip: GameEquip) => isRadar(equip) && (equip.
 // (as of Jan 1, 2020)
 export const isBuiltinHighAngleMount = (equip: GameEquip) =>
   isHighAngleMount(equip) && (equip.api_tyku ?? 0) >= 8
+// 素対空9以上の特殊高角砲 (AACI id 53)
+export const isBuiltinHighAngleMountAA9 = (equip: GameEquip) =>
+  isHighAngleMount(equip) && (equip.api_tyku ?? 0) >= 9
 
 // 21=対空機銃
 export const isMachineGun = itemTypeIs(21)

--- a/views/utils/combat/oasw.md
+++ b/views/utils/combat/oasw.md
@@ -5,7 +5,7 @@
 
 **Wiki reference**: https://wikiwiki.jp/kancolle/%E5%AF%BE%E6%BD%9C%E6%94%BB%E6%92%83#oasw (発動条件 section)
 
-## Validated Conditions (as of 2026-05-27)
+## Validated Conditions (as of 2026-08-12)
 
 All logic matches the wiki. 龍田改二 (ship ID 478) is now the shared `isTatsutaK2` predicate; 日向改二 (554) the shared `isHyuuGaK2`.
 
@@ -21,6 +21,11 @@ All logic matches the wiki. 龍田改二 (ship ID 478) is now the shared `isTats
 | `isSamuelKai`          | 681                    | Samuel B. Roberts改           |
 | `isSamuelKaiNi`        | 920                    | Samuel B. Roberts改二 (Mk.II) |
 | `isFletcherClassOrKai` | 562, 596, ctype=91+Kai | Fletcher級                    |
+| `isVisbyOrKai`         | 1062, 1067             | Visby / Visby改               |
+| `isHiedaMaruOrKai`     | 1065, 1070             | 日枝丸 / 日枝丸改             |
+
+日枝丸 is a 潜水母艦 (stype 20), which the general 対潜100+ソナー branch below does
+not cover, so the unconditional entry is the only thing that makes it fire.
 
 ### 海防艦 (DE, stype=1)
 

--- a/views/utils/combat/oasw.ts
+++ b/views/utils/combat/oasw.ts
@@ -51,6 +51,13 @@ const isMogamiClassKouKaiNi: OASWPredicate = (ship) =>
 
 const isYuubariKaiNiTei = shipIdIs(624)
 
+// Visby (1062) / Visby改 (1067)
+const isVisbyOrKai: OASWPredicate = (ship) => ship.api_ship_id === 1062 || ship.api_ship_id === 1067
+// 日枝丸 (1065) / 日枝丸改 (1070); 潜水母艦 (stype 20), so not covered by the
+// 駆逐/軽巡/雷巡/練巡/補給 branch below
+const isHiedaMaruOrKai: OASWPredicate = (ship) =>
+  ship.api_ship_id === 1065 || ship.api_ship_id === 1070
+
 const isKagaKaiNiGo = shipIdIs(646)
 
 const isShinShuMaruKai = shipIdIs(626)
@@ -84,6 +91,8 @@ export const isOASW: OASWPredicate = overSome(
   isFletcherClassOrKai,
   isSamuelKaiNi,
   isFubukiK3Go,
+  isVisbyOrKai,
+  isHiedaMaruOrKai,
   // 海防艦
   overEvery(
     isDE,

--- a/views/utils/combat/ship-predicates.ts
+++ b/views/utils/combat/ship-predicates.ts
@@ -82,5 +82,7 @@ export const isFujinamiK2 = shipIdIs(981)
 export const isHayanamiK2 = shipIdIs(982)
 export const isHamanamiK2 = shipIdIs(983)
 export const isTamananiK2 = shipIdIs(1033)
+// 1034: 涼波改二, 745: 涼波改二補 — both count as 三十二駆改二
+export const isSuzunamiK2 = shipIdIsOneOf(1034, 745)
 export const isShirayukiK2 = shipIdIs(986)
 export const isHatsuyukiK2 = shipIdIs(987)

--- a/views/utils/combat/sp-attack.ts
+++ b/views/utils/combat/sp-attack.ts
@@ -205,13 +205,15 @@ const isColoradoSpAttack = overEvery([
 ])
 
 // https://wikiwiki.jp/kancolle/%E9%87%91%E5%89%9B%E6%94%B9%E4%BA%8C%E4%B8%99#SpecialAttack
+// NOTE: unlike the other special attacks, both the flagship and the companion
+// only need to be 大破未満 here — 中破 still triggers.
 const isKongoClassKaiNiCSpAttack = overEvery([
   isSpAttackLessThan([SP_ATTACK_ID.Kongo_Class_Kaini_C_Charge])(3),
   isFleetWith5NonSubs,
   overSome([
     // Kongo Kai Ni C
     overEvery([
-      overShip(0)(shipEvery([isKongoKaiNiC, isNotMidDmg])),
+      overShip(0)(shipEvery([isKongoKaiNiC, isNotHeavyDmg])),
       overShip(1)(
         shipEvery([
           shipSome([
@@ -223,13 +225,13 @@ const isKongoClassKaiNiCSpAttack = overEvery([
             isWarspite,
             isValiant,
           ]),
-          isNotMidDmg,
+          isNotHeavyDmg,
         ]),
       ),
     ]),
     // Hiei Kai Ni C
     overEvery([
-      overShip(0)(shipEvery([isHieiKaiNiC, isNotMidDmg])),
+      overShip(0)(shipEvery([isHieiKaiNiC, isNotHeavyDmg])),
       overShip(1)(
         shipEvery([
           shipSome([
@@ -239,24 +241,24 @@ const isKongoClassKaiNiCSpAttack = overEvery([
             isKirishimaKaiNi,
             isKirishimaKaiNiC,
           ]),
-          isNotMidDmg,
+          isNotHeavyDmg,
         ]),
       ),
     ]),
     // Haruna Kai Ni B/C
     overEvery([
-      overShip(0)(shipEvery([shipSome([isHarunaKaiNiB, isHarunaKaiNiC]), isNotMidDmg])),
+      overShip(0)(shipEvery([shipSome([isHarunaKaiNiB, isHarunaKaiNiC]), isNotHeavyDmg])),
       overShip(1)(
-        shipEvery([shipSome([isKongoKaiNiC, isHieiKaiNiC, isKirishimaKaiNiC]), isNotMidDmg]),
+        shipEvery([shipSome([isKongoKaiNiC, isHieiKaiNiC, isKirishimaKaiNiC]), isNotHeavyDmg]),
       ),
     ]),
     // Kirishima Kai Ni C
     overEvery([
-      overShip(0)(shipEvery([isKirishimaKaiNiC, isNotMidDmg])),
+      overShip(0)(shipEvery([isKirishimaKaiNiC, isNotHeavyDmg])),
       overShip(1)(
         shipEvery([
           shipSome([isKongoKaiNiC, isHieiKaiNiC, isHarunaKaiNiB, isHarunaKaiNiC, isSouthDakotaKai]),
-          isNotMidDmg,
+          isNotHeavyDmg,
         ]),
       ),
     ]),


### PR DESCRIPTION
Sweeps `views/utils/combat` against current game data. Ship/equipment ids were checked against `api_start2` master data from a response-saver capture; conditions against the wikiwiki [対潜攻撃](https://wikiwiki.jp/kancolle/%E5%AF%BE%E6%BD%9C%E6%94%BB%E6%92%83), [対空カットイン一覧表](https://wikiwiki.jp/kancolle/%E5%AF%BE%E7%A9%BA%E7%A0%B2%E7%81%AB/%E5%AF%BE%E7%A9%BA%E3%82%AB%E3%83%83%E3%83%88%E3%82%A4%E3%83%B3%E4%B8%80%E8%A6%A7%E8%A1%A8) and [金剛改二丙](https://wikiwiki.jp/kancolle/%E9%87%91%E5%89%9B%E6%94%B9%E4%BA%8C%E4%B8%99) pages.

## OASW

Two ships were missing from the unconditional (装備不問) branch:

| Ship | IDs |
| --- | --- |
| Visby / Visby改 | 1062, 1067 |
| 日枝丸 / 日枝丸改 | 1065, 1070 |

日枝丸 is a 潜水母艦 (stype 20), which none of the ship-type branches cover, so the unconditional entry is the only thing that makes it fire.

Re-verified as still correct while in here: 加賀改二護 (no 対潜値 threshold), 大鷹型改/改二, 扶桑改二/山城改二, 熊野丸/改, 神州丸改, 大和改二重.

## AACI

- **New type 53** (飛龍改三): 素対空9以上の特殊高角砲 + 素対空4以上の対空電探, 固定 4, 変動 1.6.
  The wiki still marks the 変動ボーナス cell with `?` — flagged in a code comment so it can be revisited once confirmed.
- **Types 49~52**: added 涼波改二 (1034) and 涼波改二補 (745), which count as 三十二駆改二 alongside 藤波/早波/浜波/玉波改二.
  The four entries shared an identical 10-name ship list, so they now share one `isFubukiOr32ndDivisionK2` predicate and one name list (type 50 adds 秋月型 on top) — the next member is a one-line change.
- **Resolver fix**: `getShipAACIs` picked the winning type with `maxBy` on `fixed` alone, so ties resolved to whichever entry happened to register first. Type 53 and the generic type 8 both have `fixed: 4`, so 飛龍改三 would have kept reporting type 8 (×1.4) instead of its exclusive ×1.6. Replaced with a reducer that tie-breaks on `modifier`, which is the ordering `sortAaciIds` in the same file already used — this makes the two consistent rather than introducing a new rule.

  Note this also changes tie resolution for any other equal-`fixed` pair; preferring the higher modifier is strictly the better CI in that case, and the suite is green.

## sp-attack

金剛型改二丙 required 中破未満 on both the flagship and the companion. The wiki states 「旗艦/僚艦とも**大破未満**（どちらかが大破すると発動不可）」 — 中破 still triggers. Both slots switched to `isNotHeavyDmg`. The 3-per-sortie limit was already correct.

## Tests

11 new cases across the three modules:

- OASW: unconditional trigger for all four new ids, plus a control 潜水母艦 (平安丸) that should still *not* fire.
- AACI: type 53 trigger, both equipment thresholds, and ship exclusivity; parameterised 三十二駆改二 case covering 玉波改二 (existing member, as control) / 涼波改二 / 涼波改二補, plus a negative for 長波改二補 (743), which is not in that group.
- sp-attack: 金剛型改二丙 triggers at 中破 on either slot, and does not at 大破.

`npm test` 254 passed, `npm run typecheck` and `npm run lint:js` clean.

## Out of scope

Three limited-time quests seen in captures are not tracked in `assets/data/quest_goal.cson` — 382 (第三十一戦隊 緊急演習), 383 (フランス艦隊、特別演習), 1048 (戦略兵站物資、緊急輸送). Deliberately left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
