### PR TITLE
fix(views): re-measure Blueprint sliders and tabs when laid out

### DIFF
--- a/views/env.ts
+++ b/views/env.ts
@@ -82,6 +82,9 @@ if (process.env.NODE_ENV === 'production' && config.get?.('poi.misc.exceptionRep
   })
 }
 
+// Fix Blueprint components mounted in a non-laid-out subtree (also covers plugins)
+require('./polyfills/blueprint-measurement')
+
 // Polyfill for old plugins
 require('./polyfills/react-bootstrap')
 require('./polyfills/react-fontawesome')

--- a/views/polyfills/blueprint-measurement.ts
+++ b/views/polyfills/blueprint-measurement.ts
@@ -11,35 +11,76 @@
  * plugins share one module instance, and the exports object is read-only.
  *
  * Private members are reached by element access, which TypeScript permits
- * without asserting the instance type away.
+ * without asserting the instance type away. Since those members are internal to
+ * Blueprint and may be renamed by a future version, every one of them is checked
+ * at runtime before patching: if any is missing the component is left untouched,
+ * so a version bump degrades to the unpatched behaviour instead of throwing
+ * during mount or unmount.
  */
 export {}
+
+import type { Component } from 'react'
 
 import { MultiSlider, Tabs } from '@blueprintjs/core'
 
 const observers = new WeakMap<object, ResizeObserver>()
 
 /**
- * Only measure once the element is actually laid out. A zero-sized callback is
- * either the initial observation or the tab being hidden again; re-measuring
- * then would just overwrite good numbers with zeroes, and the observer fires
- * again with real values when the element comes back.
+ * Re-run `measure` whenever the observed element is actually laid out. A
+ * zero-sized callback is either the initial observation or the tab being hidden
+ * again; re-measuring then would just overwrite good numbers with zeroes, and
+ * the observer fires again with real values when the element comes back.
  */
-const observeLayout = (instance: object, element: Element, measure: () => void) => {
-  const observer = new ResizeObserver(([entry]) => {
-    const { width, height } = entry.contentRect
-    if (width === 0 && height === 0) {
+const patchMeasurement = <T extends Component>({
+  name,
+  prototype,
+  hasInternals,
+  getElement,
+  measure,
+}: {
+  name: string
+  prototype: T
+  /** whether the private method `measure` calls is still there to call */
+  hasInternals: boolean
+  getElement: (instance: T) => Element | null
+  measure: (instance: T) => void
+}): void => {
+  const { componentDidMount, componentWillUnmount } = prototype
+
+  if (
+    !hasInternals ||
+    typeof componentDidMount !== 'function' ||
+    typeof componentWillUnmount !== 'function'
+  ) {
+    console.warn(`[blueprint-measurement] ${name} internals changed; skipping the re-measure patch`)
+    return
+  }
+
+  prototype.componentDidMount = function (this: T) {
+    componentDidMount.call(this)
+
+    const element = getElement(this)
+    if (element == null) {
       return
     }
-    measure()
-  })
-  observer.observe(element)
-  observers.set(instance, observer)
-}
 
-const disconnectLayoutObserver = (instance: object) => {
-  observers.get(instance)?.disconnect()
-  observers.delete(instance)
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      if (width === 0 && height === 0) {
+        return
+      }
+      measure(this)
+    })
+    observer.observe(element)
+    observers.set(this, observer)
+  }
+
+  prototype.componentWillUnmount = function (this: T) {
+    observers.get(this)?.disconnect()
+    observers.delete(this)
+
+    componentWillUnmount.call(this)
+  }
 }
 
 /**
@@ -50,23 +91,13 @@ const disconnectLayoutObserver = (instance: object) => {
  * (poooi/poi#2692, upstream palantir/blueprint#4109). Window resizes leave the
  * same measurement stale.
  */
-{
-  const { componentDidMount, componentWillUnmount } = MultiSlider.prototype
-
-  MultiSlider.prototype.componentDidMount = function () {
-    componentDidMount.call(this)
-
-    const track = this['trackElement']
-    if (track != null) {
-      observeLayout(this, track, () => this['updateTickSize']())
-    }
-  }
-
-  MultiSlider.prototype.componentWillUnmount = function () {
-    disconnectLayoutObserver(this)
-    componentWillUnmount.call(this)
-  }
-}
+patchMeasurement({
+  name: 'MultiSlider',
+  prototype: MultiSlider.prototype,
+  hasInternals: typeof MultiSlider.prototype['updateTickSize'] === 'function',
+  getElement: (slider) => slider['trackElement'],
+  measure: (slider) => slider['updateTickSize'](),
+})
 
 /**
  * <Tabs> positions its selection indicator from the selected tab's measured box,
@@ -75,22 +106,12 @@ const disconnectLayoutObserver = (instance: object) => {
  * there until the user switches tabs — poi's settings view mounts exactly that
  * way. Re-measuring on resize also covers upstream palantir/blueprint#1035.
  */
-{
-  const { componentDidMount, componentWillUnmount } = Tabs.prototype
-
-  Tabs.prototype.componentDidMount = function () {
-    componentDidMount.call(this)
-
-    const tablist = this['tablistElement']
-    if (tablist != null) {
-      // `false` so the indicator appears in place instead of sliding in from the
-      // origin the first time the tab bar is revealed
-      observeLayout(this, tablist, () => this['moveSelectionIndicator'](false))
-    }
-  }
-
-  Tabs.prototype.componentWillUnmount = function () {
-    disconnectLayoutObserver(this)
-    componentWillUnmount.call(this)
-  }
-}
+patchMeasurement({
+  name: 'Tabs',
+  prototype: Tabs.prototype,
+  hasInternals: typeof Tabs.prototype['moveSelectionIndicator'] === 'function',
+  getElement: (tabs) => tabs['tablistElement'],
+  // `false` so the indicator appears in place instead of sliding in from the
+  // origin the first time the tab bar is revealed
+  measure: (tabs) => tabs['moveSelectionIndicator'](false),
+})

--- a/views/polyfills/blueprint-measurement.ts
+++ b/views/polyfills/blueprint-measurement.ts
@@ -1,0 +1,96 @@
+/**
+ * Several Blueprint components measure the DOM once on mount and derive layout
+ * from that measurement, without re-measuring when their box later changes size.
+ * poi keeps inactive tabs mounted under `content-visibility: hidden`, whose
+ * subtree is never laid out, so anything inside a settings or plugin tab mounts
+ * against a 0px box and stays broken after the tab is first revealed.
+ *
+ * These patches re-run the component's own measurement whenever its element
+ * actually has a size. They patch the prototype rather than wrapping components,
+ * so plugins importing straight from @blueprintjs/core are covered too — poi and
+ * plugins share one module instance, and the exports object is read-only.
+ *
+ * Private members are reached by element access, which TypeScript permits
+ * without asserting the instance type away.
+ */
+export {}
+
+import { MultiSlider, Tabs } from '@blueprintjs/core'
+
+const observers = new WeakMap<object, ResizeObserver>()
+
+/**
+ * Only measure once the element is actually laid out. A zero-sized callback is
+ * either the initial observation or the tab being hidden again; re-measuring
+ * then would just overwrite good numbers with zeroes, and the observer fires
+ * again with real values when the element comes back.
+ */
+const observeLayout = (instance: object, element: Element, measure: () => void) => {
+  const observer = new ResizeObserver(([entry]) => {
+    const { width, height } = entry.contentRect
+    if (width === 0 && height === 0) {
+      return
+    }
+    measure()
+  })
+  observer.observe(element)
+  observers.set(instance, observer)
+}
+
+const disconnectLayoutObserver = (instance: object) => {
+  observers.get(instance)?.disconnect()
+  observers.delete(instance)
+}
+
+/**
+ * <MultiSlider> (which backs <Slider> and <RangeSlider>) measures its track once
+ * on mount, and only re-measures when min/max/vertical change. Pointer movement
+ * is converted to values with that measurement, so a 0px track makes every drag
+ * divide by zero and resolve to ±Infinity — the handle snaps between min and max
+ * (poooi/poi#2692, upstream palantir/blueprint#4109). Window resizes leave the
+ * same measurement stale.
+ */
+{
+  const { componentDidMount, componentWillUnmount } = MultiSlider.prototype
+
+  MultiSlider.prototype.componentDidMount = function () {
+    componentDidMount.call(this)
+
+    const track = this['trackElement']
+    if (track != null) {
+      observeLayout(this, track, () => this['updateTickSize']())
+    }
+  }
+
+  MultiSlider.prototype.componentWillUnmount = function () {
+    disconnectLayoutObserver(this)
+    componentWillUnmount.call(this)
+  }
+}
+
+/**
+ * <Tabs> positions its selection indicator from the selected tab's measured box,
+ * and only re-measures when the selection or the tab children change. Mounted
+ * unlaid-out, the indicator collapses to a zero-sized box at the origin and stays
+ * there until the user switches tabs — poi's settings view mounts exactly that
+ * way. Re-measuring on resize also covers upstream palantir/blueprint#1035.
+ */
+{
+  const { componentDidMount, componentWillUnmount } = Tabs.prototype
+
+  Tabs.prototype.componentDidMount = function () {
+    componentDidMount.call(this)
+
+    const tablist = this['tablistElement']
+    if (tablist != null) {
+      // `false` so the indicator appears in place instead of sliding in from the
+      // origin the first time the tab bar is revealed
+      observeLayout(this, tablist, () => this['moveSelectionIndicator'](false))
+    }
+  }
+
+  Tabs.prototype.componentWillUnmount = function () {
+    disconnectLayoutObserver(this)
+    componentWillUnmount.call(this)
+  }
+}


### PR DESCRIPTION
Fixes #2692

## Problem

Blueprint's `MultiSlider` (behind `Slider` / `RangeSlider`) measures its track width once on mount, and only re-measures when `min`/`max`/`vertical` change. Pointer movement is converted to values with that measurement:

```js
value + Math.round(pixelDelta / (tickSize * stepSize)) * stepSize
```

Since 12.0.0-beta, inactive tabs stay mounted under `content-visibility: hidden` so plugin state survives tab switches. That subtree is never laid out, so every slider in a settings or plugin tab mounts against a 0px track — the division yields ±Infinity and the handle snaps between `min` and `max`, which is the zoom slider behaviour reported in #2692. Window resizes leave the same measurement stale.

`Tabs` has the same defect: the selection indicator is positioned from the selected tab's measured box on mount, and only re-measured when the selection or the tab children change. The settings view mounts unlaid-out, so its indicator collapses to a zero-sized box at the origin until you click another settings tab.

Upstream has both open: palantir/blueprint#4109 (range slider in a non-active tab) and palantir/blueprint#1035 (tab indicator after resize).

## Fix

`views/polyfills/blueprint-measurement.ts` patches both prototypes to re-run the component's own measurement through a `ResizeObserver` whenever the element actually has a size.

Patching the prototype rather than wrapping the components means plugins importing `Slider` straight from `@blueprintjs/core` are fixed without any change on their side — poi and plugins share one module instance, and the exports object is read-only (assigning to it silently no-ops), so this is also the only interception point that works.

Callbacks with a 0×0 box are ignored, so hiding a tab again does not overwrite good measurements with zeroes; the observer fires again with real values when the tab comes back.

## Notes

- Audited the other DOM-measuring components in the installed Blueprint packages. `OverflowList` already uses a `ResizeSensor`; `Collapse`, `EditableText`, `ResizableInput`, `Text`, `QueryList` and the datetime/popover helpers either treat a 0 measurement as unknown or only measure during interaction, so none of them need this.
- `MultiSlider` and `Tabs` are `PureComponent`s and re-measuring writes equal state, so a no-op measurement does not re-render, and neither observed element is sized by what the measurement changes — no observer feedback loop.

## Test plan

- Open Settings → Display and drag the zoom slider: it now follows the pointer instead of jumping between 50% and 400%. Same for the notification volume and FPS limit sliders.
- Open Settings for the first time: the tab indicator is positioned correctly without having to switch tabs.
- `npm run typecheck` and `npm run lint:js` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
