### PR TITLE
fix: ipc register function does not update upon plugin list update

### DIFF
--- a/views/components/tab-area/index.tsx
+++ b/views/components/tab-area/index.tsx
@@ -341,23 +341,38 @@ const ControlledTabAreaFC = (): React.ReactElement => {
     [plugins, isWindowMode, handleSelectTab, openWindow],
   )
 
+  // The registrations below happen once on mount, so they must not close over
+  // a stale render's handlers. Keep the latest ones in a ref and call through it.
+  const latestRef = useRef({ selectTab, ipcFocusPlugin, handleConfig, activePluginName, plugins })
+  useLayoutEffect(() => {
+    latestRef.current = { selectTab, ipcFocusPlugin, handleConfig, activePluginName, plugins }
+  })
+
   useEffect(() => {
+    const onConfigSet = (path: ConfigStringPath) => latestRef.current.handleConfig(path)
+    const onTouchbarTab = (_event: unknown, message: number) => {
+      const {
+        activePluginName: activePlugin,
+        plugins: allPlugins,
+        selectTab: select,
+      } = latestRef.current
+      const keys = ['main-view', 'ship-view', activePlugin || allPlugins[0]?.packageName]
+      select(keys[message] ?? '')
+    }
+
     registerKeyboard()
     window.addEventListener('game.start', registerKeyboard)
     window.addEventListener('game.response', handleResponse)
-    window.openSettings = () => selectTab('settings')
+    window.openSettings = () => latestRef.current.selectTab('settings')
     ipc.register('MainWindow', {
-      ipcFocusPlugin: (id: string) => ipcFocusPlugin(id),
+      ipcFocusPlugin: (id: string) => latestRef.current.ipcFocusPlugin(id),
     })
 
     if (process.platform === 'darwin') {
-      require('electron').ipcRenderer.on('touchbartab', (_event: unknown, message: number) => {
-        const keys = ['main-view', 'ship-view', activePluginName || plugins[0]?.packageName]
-        selectTab(keys[message] ?? '')
-      })
+      require('electron').ipcRenderer.on('touchbartab', onTouchbarTab)
     }
 
-    config.addListener('config.set', handleConfig)
+    config.addListener('config.set', onConfigSet)
 
     setTimeout(() => {
       const tabsInstance = tabsRef.current
@@ -371,7 +386,10 @@ const ControlledTabAreaFC = (): React.ReactElement => {
       window.removeEventListener('game.start', registerKeyboard)
       window.removeEventListener('game.response', handleResponse)
       ipc.unregisterAll('MainWindow')
-      config.removeListener('config.set', handleConfig)
+      config.removeListener('config.set', onConfigSet)
+      if (process.platform === 'darwin') {
+        require('electron').ipcRenderer.removeListener('touchbartab', onTouchbarTab)
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
## Problem

`ControlledTabAreaFC` registers its keyboard / IPC / config listeners once on mount (empty dep array), so the callbacks it hands out capture the first render's `selectTab`, `ipcFocusPlugin`, `handleConfig`, `activePluginName` and `plugins`. Once the plugin list updates, `ipcFocusPlugin` keeps operating on the stale list, so focusing a plugin by IPC targets the wrong tab (or nothing).

## Fix

Keep the latest handlers in a ref refreshed on every render via `useLayoutEffect`, and have the mount-time registrations call through that ref instead of closing over render-scoped values. Also removes the `touchbartab` listener on unmount, which was previously left attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
