### PR TITLE
fix: task panel renders a single column regardless of width

### DIFF
--- a/views/components/main/parts/task-panel.tsx
+++ b/views/components/main/parts/task-panel.tsx
@@ -145,6 +145,13 @@ const ScollShadowWrapper = styled(ScrollShadow)`
   overflow: auto;
 `
 
+// task items lay out in columns; the wrapping row lives here rather than on
+// ScrollShadow's container, whose sentinels must stay full-width block siblings
+const TaskList = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+`
+
 const TaskItem = styled.div<{ colwidth: number }>`
   align-items: center;
   display: flex;
@@ -453,7 +460,7 @@ const TaskPanelContent = ({
 }) => {
   const { t } = useTranslation('main')
   return (
-    <>
+    <TaskList>
       {sortBy(map(values(activeQuests), 'detail'), 'api_no').map((quest, idx) => (
         <TaskRow key={quest?.api_no ?? idx} idx={idx} quest={quest} colwidth={colwidth} />
       ))}
@@ -478,6 +485,6 @@ const TaskPanelContent = ({
           />
         ),
       )}
-    </>
+    </TaskList>
   )
 }


### PR DESCRIPTION
## Problem

The quest panel only ever renders one column, even when the panel is wide enough for 2–4.

`getPanelDimension` still computes the right column count and `TaskItem` still sets `width: colwidth / 12 * 100%`, but nothing lays them out in a row anymore. Up to v11, `CardWrapper` itself was `display: flex; flex-flow: row wrap`. When `ScrollShadow` was introduced, `CardWrapper` became `flex-direction: column` and the rows moved inside the scroll container — a plain block, so every percentage-width item gets its own line.

## Fix

Restore the wrapping row as a `TaskList` element around the quest rows. It cannot go on the `ScrollShadow` container itself, whose top/bottom intersection sentinels need to stay full-width block siblings of the content.

Breakpoints are untouched, so the column counts match v11 again (350 / 525 / 700 px → 2 / 3 / 4 columns).

The other main panels were checked against v11 and need no change: `resource-panel` still wraps on its own `CardWrapper`, `repair-panel` / `construction-panel` still use the `Panel` container-query grid, and the remaining panels are single-column by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
