### PR TITLE
feat: update fighter power formula

### DIFF
--- a/views/utils/__tests__/game-utils.spec.ts
+++ b/views/utils/__tests__/game-utils.spec.ts
@@ -17,14 +17,33 @@ const $equip = (mstId: number): APIMstSlotitem => {
 const JET_FIGHTER = 548
 // 20: 零式艦戦52型, a plain 艦上戦闘機 with the same proficiency bonus table
 const CARRIER_FIGHTER = 20
+// 186: 一式陸攻 三四型 (陸上攻撃機, AA 4)
+const LAND_BASED_ATTACKER = 186
+// 396: 深山改 (大型陸上機, AA 2)
+const HEAVY_BOMBER = 396
+// 352: 秋水 (局地戦闘機, AA 3 — below the old `api_tyku > 3` improvement cutoff)
+const INTERCEPTOR = 352
+// 311 / 312: 二式陸上偵察機 and its 熟練 variant (陸上偵察機, AA 3, 索敵 8 / 9)
+const LAND_BASED_RECON = 311
+const LAND_BASED_RECON_SKILLED = 312
+
+/** Land base action kinds, as passed to `getTyku` */
+const SORTIE = 1
+const AIR_DEFENSE = 2
 
 const equip = (mstId: number, { alv = 0, level = 0 } = {}): Equip =>
   ({ api_id: 1, api_slotitem_id: mstId, api_locked: 0, api_level: level, api_alv: alv }) as Equip
 
+type Slot = [Equip, APIMstSlotitem, number]
+
 /** One ship carrying one plane, in the shape `getTyku` expects */
 const oneSlot = (mstId: number, onslot: number, opts?: { alv?: number; level?: number }) => [
-  [[equip(mstId, opts), $equip(mstId), onslot] as [Equip, APIMstSlotitem, number]],
+  [[equip(mstId, opts), $equip(mstId), onslot] as Slot],
 ]
+
+/** One ship, as `[master id, planes on slot, improvement, proficiency]` per slot */
+const ship = (...slots: [number, number, number, number][]) =>
+  slots.map(([id, onslot, level, alv]) => [equip(id, { level, alv }), $equip(id), onslot] as Slot)
 
 describe('getTyku', () => {
   spec('噴式戦闘機 counts towards fighter power', () => {
@@ -53,6 +72,87 @@ describe('getTyku', () => {
     expect(getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }), 2)).toEqual(
       getTyku(oneSlot(JET_FIGHTER, 18, { alv: 7 }), 1),
     )
+  })
+
+  spec('agrees with 制空権シミュレータ on a mixed carrier fleet', () => {
+    // Fleet from a fighter power report, which the simulator totals at 929
+    const fleet = [
+      // 赤城改二: 震電改 / 零式艦戦53型(岩本隊) / 震電改 / 試製 陣風 x2
+      ship([56, 21, 0, 7], [157, 21, 10, 7], [56, 32, 0, 7], [437, 12, 1, 7], [437, 4, 0, 7]),
+      // 由良改二: 強風改 / 強風改二 / 強風改
+      ship([217, 1, 10, 7], [485, 2, 0, 7], [217, 1, 10, 7]),
+      // Saratoga Mk.II Mod.2: AU-1 / 天山一二型(友永隊) / XF5U / Corsair Mk.II(Ace)
+      ship([475, 37, 0, 0], [94, 24, 0, 0], [375, 19, 0, 7], [435, 13, 0, 7]),
+      // Intrepid: F4U-4 / Mosquito TR Mk.33 / 烈風改二 / XF5U
+      ship([474, 37, 0, 0], [481, 36, 0, 0], [336, 19, 0, 7], [375, 4, 0, 7]),
+    ]
+    expect(fleet.map((s) => getTyku([s]).min)).toEqual([413, 97, 199, 220])
+    expect(getTyku(fleet).min).toBe(929)
+  })
+
+  spec('大型陸上機 counts towards a land base', () => {
+    // 深山改 has AA 2: sqrt(18) * 2 = 8.49
+    expect(getTyku(oneSlot(HEAVY_BOMBER, 18), SORTIE)).toEqual({ basic: 8, min: 8, max: 9 })
+  })
+
+  spec('大型陸上機 improvement adds 0.5 AA per sqrt(star)', () => {
+    // sqrt(18) * (2 + 0.5 * sqrt(10)) = 15.19
+    expect(getTyku(oneSlot(HEAVY_BOMBER, 18, { level: 10 }), SORTIE)).toEqual({
+      basic: 8,
+      min: 15,
+      max: 16,
+    })
+  })
+
+  spec('陸上攻撃機 improvement adds 0.5 AA per sqrt(star), not 0.25 per star', () => {
+    // 一式陸攻 三四型 has AA 4: sqrt(18) * (4 + 0.5 * sqrt(10)) = 23.68, and the
+    // alv 7 internal exp adds sqrt(100 / 10) on top
+    expect(getTyku(oneSlot(LAND_BASED_ATTACKER, 18, { level: 10, alv: 7 }), SORTIE)).toEqual({
+      basic: 16,
+      min: 26,
+      max: 27,
+    })
+  })
+
+  spec('局地戦闘機 improvement applies below AA 4', () => {
+    // 秋水 has AA 3 and 迎撃 0, so a sortie is worth its plain AA plus 0.2 per star
+    expect(getTyku(oneSlot(INTERCEPTOR, 18, { level: 10 }), SORTIE)).toEqual({
+      basic: 12,
+      min: 21,
+      max: 22,
+    })
+  })
+
+  spec('陸上偵察機 adds its own AA when the base is on air defense', () => {
+    // sqrt(4) * 3 = 6, times the 索敵 8 air defense multiplier 1.18
+    expect(getTyku(oneSlot(LAND_BASED_RECON, 4), AIR_DEFENSE)).toEqual({
+      basic: 7,
+      min: 7,
+      max: 7,
+    })
+  })
+
+  spec('陸上偵察機 air defense multiplier is 1.24 at 索敵 9', () => {
+    // 秋水 on air defense: sqrt(18) * (3 + 迎撃 0 + 2 * 対爆 9) = 89.09, plus the
+    // 熟練 recon's own sqrt(4) * 3 = 6, all multiplied by 1.24
+    const base = [
+      [
+        [equip(INTERCEPTOR), $equip(INTERCEPTOR), 18] as [Equip, APIMstSlotitem, number],
+        [equip(LAND_BASED_RECON_SKILLED), $equip(LAND_BASED_RECON_SKILLED), 4] as [
+          Equip,
+          APIMstSlotitem,
+          number,
+        ],
+      ],
+    ]
+    expect(getTyku(base, AIR_DEFENSE)).toEqual({ basic: 22, min: 117, max: 119 })
+  })
+
+  spec('陸上偵察機 sortie multiplier is unchanged at 1.15 / 1.18', () => {
+    const plain = getTyku(oneSlot(LAND_BASED_RECON, 4), SORTIE)
+    const skilled = getTyku(oneSlot(LAND_BASED_RECON_SKILLED, 4), SORTIE)
+    // sqrt(4) * 3 = 6, times 1.15 and 1.18
+    expect([plain.min, skilled.min]).toEqual([6, 7])
   })
 
   spec('噴式戦闘機 matches a carrier fighter of the same AA stat', () => {

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -9,20 +9,97 @@ import { shipAvatarColor } from './color'
 import { between } from './tools'
 
 const aircraftExpTable = [0, 10, 25, 40, 55, 70, 85, 100, 121]
+const MAX_AIRCRAFT_LEVEL = 7
+
+const FIGHTER_PROFICIENCY = [0, 0, 2, 5, 9, 14, 14, 22, 22]
+const BOMBER_PROFICIENCY = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+/** 制空値の熟練度ボーナス, keyed by equipment category (`api_type[2]`). */
 const aircraftLevelBonus: Record<number, number[]> = {
-  6: [0, 0, 2, 5, 9, 14, 14, 22, 22],
-  7: [0, 0, 0, 0, 0, 0, 0, 0, 0],
-  8: [0, 0, 0, 0, 0, 0, 0, 0, 0],
-  11: [0, 1, 1, 1, 1, 3, 3, 6, 6],
-  26: [0, 0, 2, 5, 9, 14, 14, 22, 22],
-  45: [0, 0, 2, 5, 9, 14, 14, 22, 22],
-  47: [0, 0, 0, 0, 0, 0, 0, 0, 0],
-  48: [0, 0, 2, 5, 9, 14, 14, 22, 22],
+  6: FIGHTER_PROFICIENCY, // 艦上戦闘機
+  7: BOMBER_PROFICIENCY, // 艦上爆撃機
+  8: BOMBER_PROFICIENCY, // 艦上攻撃機
+  11: [0, 1, 1, 1, 1, 3, 3, 6, 6], // 水上爆撃機
+  26: FIGHTER_PROFICIENCY, // 対潜哨戒機 (the 陸軍戦闘機 carried by escort carriers)
+  45: FIGHTER_PROFICIENCY, // 水上戦闘機
+  47: BOMBER_PROFICIENCY, // 陸上攻撃機
+  48: FIGHTER_PROFICIENCY, // 局地戦闘機
+  53: BOMBER_PROFICIENCY, // 大型陸上機
   // 56: 噴式戦闘機. It is a fighter, so it takes the same proficiency air power
   // bonus as 艦戦/水戦/局戦 rather than the bomber-like zeroes of the other jets.
-  56: [0, 0, 2, 5, 9, 14, 14, 22, 22],
-  57: [0, 0, 0, 0, 0, 0, 0, 0, 0],
-  58: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+  56: FIGHTER_PROFICIENCY,
+  57: BOMBER_PROFICIENCY, // 噴式戦闘爆撃機
+  58: BOMBER_PROFICIENCY, // 噴式攻撃機
+}
+
+/** Categories whose 対空 counts towards fighter power wherever they are equipped. */
+const airPowerTypes = [6, 7, 8, 11, 26, 45, 47, 48, 53, 56, 57, 58]
+
+/**
+ * 偵察機. They never contribute on a fleet, but on a land base they add their own
+ * 対空 *and* multiply the whole air corps' fighter power. 艦上偵察機 (9) cannot be
+ * deployed to a land base, so only its multiplier is ever reachable.
+ */
+const reconTypes = [9, 10, 41, 49]
+
+/**
+ * ★ improvement bonus to 対空, by category. 陸上攻撃機 and 大型陸上機 scale with
+ * √★ rather than ★ — see {@link getImprovementAABonus}.
+ */
+const improvementAAFactor: Record<number, number> = {
+  6: 0.2, // 艦上戦闘機
+  45: 0.2, // 水上戦闘機
+  47: 0.5, // 陸上攻撃機
+  48: 0.2, // 局地戦闘機
+  53: 0.5, // 大型陸上機
+}
+const sqrtImprovementTypes = [47, 53]
+
+const getImprovementAABonus = ($equip: APIMstSlotitem, level: number): number => {
+  const type = $equip.api_type[2]
+  const factor = improvementAAFactor[type]
+  if (factor != null) {
+    return factor * (sqrtImprovementTypes.includes(type) ? Math.sqrt(level) : level)
+  }
+  // 艦上爆撃機 and the jets have no category-wide rule: only 爆戦 (dive bombers
+  // carrying a fighter's 対空) benefit, so fall back to reading the stat line.
+  return $equip.api_tyku > 3 ? ($equip.api_baku > 0 ? 0.25 : 0.2) * level : 0
+}
+
+/**
+ * 局地戦闘機 spend their 迎撃 (`api_houk`) / 対爆 (`api_houm`) only on a land base.
+ * 噴式戦闘機 reuses those two stat slots for plain 回避/命中, so it is left out.
+ */
+const getInterceptionBonus = ($equip: APIMstSlotitem, landbaseStatus: number): number => {
+  if ($equip.api_type[2] !== 48) return 0
+  if (landbaseStatus === 1) return 1.5 * $equip.api_houk
+  if (landbaseStatus === 2) return $equip.api_houk + 2 * $equip.api_houm
+  return 0
+}
+
+/** 偵察機の制空値倍率. Three 索敵 tiers: 7 or below, 8, and 9 or above. */
+const getReconBonus = ($equip: APIMstSlotitem, landbaseStatus: number): number => {
+  const tier = Math.min(Math.max($equip.api_saku - 7, 0), 2)
+  const type = $equip.api_type[2]
+  if (landbaseStatus === 1) {
+    // 出撃: only 陸上偵察機 help
+    return type === 49 ? 1.12 + tier * 0.03 : 1
+  }
+  if (landbaseStatus === 2) {
+    if (type === 9) return 1.2 + tier * 0.05 // 艦上偵察機
+    if (type === 10 || type === 41) return 1.1 + tier * 0.03 // 水上偵察機 / 大型飛行艇
+    if (type === 49) return 1.12 + tier * 0.06 // 陸上偵察機
+  }
+  return 1
+}
+
+const countsTowardsAirPower = ($equip: APIMstSlotitem, landbaseStatus: number): boolean => {
+  const type = $equip.api_type[2]
+  // 三式指揮連絡機 and friends share the category with the 陸軍戦闘機 but have no 対空
+  if (type === 26) return $equip.api_tyku > 0
+  if (airPowerTypes.includes(type)) return true
+  // 偵察機 only count on a land base, and 艦上偵察機 cannot be based on one
+  return type !== 9 && reconTypes.includes(type) && (landbaseStatus === 1 || landbaseStatus === 2)
 }
 
 const speedInterpretation: Record<number, string> = {
@@ -435,94 +512,34 @@ export function getTyku(
   let maxTyku = 0
   let basicTyku = 0
   let reconBonus = 1
-  for (let i = 0; i < equipsData.length; i++) {
-    if (!equipsData[i]) {
+  for (const shipEquips of equipsData) {
+    if (!shipEquips) {
       continue
     }
-    for (let j = 0; j < equipsData[i].length; j++) {
-      const equipData = equipsData[i][j]
+    for (const equipData of shipEquips) {
       if (!equipData) {
         continue
       }
       const [_equip, $equip, onslot] = equipData
-      if ((onslot ?? 0) < 1 || onslot == undefined) {
+      if (onslot == undefined || onslot < 1) {
         continue
       }
-      let tempTyku = 0.0
-      let tempAlv
-      if (_equip.api_alv) {
-        tempAlv = _equip.api_alv
-      } else {
-        tempAlv = 0
+      const type = $equip.api_type[2]
+      if (reconTypes.includes(type)) {
+        reconBonus = Math.max(reconBonus, getReconBonus($equip, landbaseStatus))
       }
-      const levelFactor = $equip.api_tyku > 3 ? ($equip.api_baku > 0 ? 0.25 : 0.2) : 0
-      if (
-        // 56 (噴式戦闘機) uses the plain fighter formula on both fleets and land
-        // bases: unlike 局地戦闘機 it has no 迎撃/対爆 stats, so no landbase bonus.
-        [6, 7, 45, 47, 56, 57].includes($equip.api_type[2]) ||
-        ([26].includes($equip.api_type[2]) && $equip.api_tyku > 0)
-      ) {
-        tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)
-        tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
-        basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-      } else if ([8, 11].includes($equip.api_type[2])) {
-        tempTyku += Math.sqrt(onslot) * $equip.api_tyku
-        tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
-        basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-      } else if ([48].includes($equip.api_type[2])) {
-        let landbaseBonus = 0
-        if (landbaseStatus === 1) landbaseBonus = 1.5 * $equip.api_houk
-        if (landbaseStatus === 2) landbaseBonus = $equip.api_houk + 2 * $equip.api_houm
-        tempTyku +=
-          Math.sqrt(onslot) *
-          ($equip.api_tyku + landbaseBonus + (_equip.api_level || 0) * levelFactor)
-        tempTyku += aircraftLevelBonus[$equip.api_type[2]][tempAlv]
-        basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-        minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-        maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-      } else if ([10, 41].includes($equip.api_type[2])) {
-        if (landbaseStatus == 2) {
-          if ($equip.api_saku >= 9) {
-            reconBonus = Math.max(reconBonus, 1.16)
-          } else if ($equip.api_saku == 8) {
-            reconBonus = Math.max(reconBonus, 1.13)
-          } else {
-            reconBonus = Math.max(reconBonus, 1.1)
-          }
-        } else if (landbaseStatus == 1) {
-          tempTyku += Math.sqrt(onslot) * $equip.api_tyku
-          minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-          maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-        }
-      } else if ([9].includes($equip.api_type[2]) && landbaseStatus == 2) {
-        if ($equip.api_saku >= 9) {
-          reconBonus = Math.max(reconBonus, 1.3)
-        } else {
-          reconBonus = Math.max(reconBonus, 1.2)
-        }
-      } else if ([49].includes($equip.api_type[2])) {
-        if (landbaseStatus == 1) {
-          tempTyku += Math.sqrt(onslot) * ($equip.api_tyku + (_equip.api_level || 0) * levelFactor)
-          basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
-          minTyku += Math.floor(tempTyku + Math.sqrt(aircraftExpTable[tempAlv] / 10))
-          maxTyku += Math.floor(tempTyku + Math.sqrt((aircraftExpTable[tempAlv + 1] - 1) / 10))
-          if ($equip.api_saku >= 9) {
-            reconBonus = Math.max(reconBonus, 1.18)
-          } else {
-            reconBonus = Math.max(reconBonus, 1.15)
-          }
-        } else if (landbaseStatus == 2) {
-          if ($equip.api_saku >= 9) {
-            reconBonus = Math.max(reconBonus, 1.23)
-          } else {
-            reconBonus = Math.max(reconBonus, 1.18)
-          }
-        }
+      if (!countsTowardsAirPower($equip, landbaseStatus)) {
+        continue
       }
+      const alv = Math.min(_equip.api_alv || 0, MAX_AIRCRAFT_LEVEL)
+      const aa =
+        $equip.api_tyku +
+        getImprovementAABonus($equip, _equip.api_level || 0) +
+        getInterceptionBonus($equip, landbaseStatus)
+      const tyku = Math.sqrt(onslot) * aa + (aircraftLevelBonus[type]?.[alv] ?? 0)
+      basicTyku += Math.floor(Math.sqrt(onslot) * $equip.api_tyku)
+      minTyku += Math.floor(tyku + Math.sqrt(aircraftExpTable[alv] / 10))
+      maxTyku += Math.floor(tyku + Math.sqrt((aircraftExpTable[alv + 1] - 1) / 10))
     }
   }
   return {


### PR DESCRIPTION
## What

Rewrites `getTyku` (制空値) in `views/utils/game-utils.ts`. The old code was a chain of `else if` branches keyed by equipment category, each repeating the same `√onslot × 対空 + 熟練度` arithmetic with slightly different details, which made the missing cases hard to spot.

The formula is now split into named pieces — `countsTowardsAirPower`, `getImprovementAABonus`, `getInterceptionBonus`, `getReconBonus` — with a single shared accumulation loop, and the proficiency table is annotated with the 艦戦/艦爆 category names.

## Behavior changes

- 大型陸上機 (53) now counts towards air power, with bomber proficiency and the √★ improvement bonus.
- 艦上攻撃機 (8) and 水上爆撃機 (11) now go through the same ★ improvement path as the rest instead of being special-cased to base 対空 only; in practice this only moves the number for equips with 対空 > 3 (爆戦).
- 陸上攻撃機 (47) and 大型陸上機 (53) use the √★ improvement scaling; 艦戦/水戦/局戦 use 0.2 × ★, 爆戦 0.25 × ★.
- 偵察機 multipliers reworked into three 索敵 tiers (≤7 / 8 / ≥9) rather than two, and 陸上偵察機 (49) keeps contributing its own 対空 on 出撃.
- `api_alv` is clamped to 7, so an out-of-range proficiency no longer indexes past the bonus table.

## Tests

`views/utils/__tests__/game-utils.spec.ts` gains coverage for the new categories, the improvement bonuses, the interception bonus on both land-base statuses, and the recon multiplier tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
