### PR TITLE
feat(global-search): mirror the remodel and land base screens as scene switches

### DIFF
--- a/i18n/main/en-US.json
+++ b/i18n/main/en-US.json
@@ -156,5 +156,8 @@
   "Right-click a plugin for more options": "Right-click a plugin for more options",
   "編成": "Organize",
   "改装": "Remodel",
-  "The remodel screen has no sort": "The remodel screen has no sort"
+  "The remodel screen has no sort": "The remodel screen has no sort",
+  "装備": "Equipment",
+  "基地航空隊": "Land Base",
+  "The land base has its own tabs": "The land base has its own tabs"
 }

--- a/i18n/main/en-US.json
+++ b/i18n/main/en-US.json
@@ -159,5 +159,6 @@
   "The remodel screen has no sort": "The remodel screen has no sort",
   "装備": "Equipment",
   "基地航空隊": "Land Base",
-  "The land base has its own tabs": "The land base has its own tabs"
+  "The land base has its own tabs": "The land base has its own tabs",
+  "The remodel screen has no tag filter": "The remodel screen has no tag filter"
 }

--- a/i18n/main/en-US.json
+++ b/i18n/main/en-US.json
@@ -153,5 +153,8 @@
   "The ex-slot lists every equipment": "The ex-slot lists every equipment",
   "Right-click a ship for more options": "Right-click a ship for more options",
   "Got it": "Got it",
-  "Right-click a plugin for more options": "Right-click a plugin for more options"
+  "Right-click a plugin for more options": "Right-click a plugin for more options",
+  "編成": "Organize",
+  "改装": "Remodel",
+  "The remodel screen has no sort": "The remodel screen has no sort"
 }

--- a/i18n/main/ja-JP.json
+++ b/i18n/main/ja-JP.json
@@ -173,5 +173,6 @@
   "The remodel screen has no sort": "改装画面には並び替えがありません",
   "装備": "装備",
   "基地航空隊": "基地航空隊",
-  "The land base has its own tabs": "基地航空隊は専用のタブで絞り込みます"
+  "The land base has its own tabs": "基地航空隊は専用のタブで絞り込みます",
+  "The remodel screen has no tag filter": "改装画面にはタグ絞り込みがありません"
 }

--- a/i18n/main/ja-JP.json
+++ b/i18n/main/ja-JP.json
@@ -167,5 +167,8 @@
   "The ex-slot lists every equipment": "補強増設では全装備が表示されます",
   "Right-click a ship for more options": "艦娘を右クリックするとメニューが開きます",
   "Got it": "了解",
-  "Right-click a plugin for more options": "プラグインを右クリックするとメニューが開きます"
+  "Right-click a plugin for more options": "プラグインを右クリックするとメニューが開きます",
+  "編成": "編成",
+  "改装": "改装",
+  "The remodel screen has no sort": "改装画面には並び替えがありません"
 }

--- a/i18n/main/ja-JP.json
+++ b/i18n/main/ja-JP.json
@@ -170,5 +170,8 @@
   "Right-click a plugin for more options": "プラグインを右クリックするとメニューが開きます",
   "編成": "編成",
   "改装": "改装",
-  "The remodel screen has no sort": "改装画面には並び替えがありません"
+  "The remodel screen has no sort": "改装画面には並び替えがありません",
+  "装備": "装備",
+  "基地航空隊": "基地航空隊",
+  "The land base has its own tabs": "基地航空隊は専用のタブで絞り込みます"
 }

--- a/i18n/main/ko-KR.json
+++ b/i18n/main/ko-KR.json
@@ -162,5 +162,8 @@
   "The ex-slot lists every equipment": "보강증설 슬롯은 모든 장비를 표시합니다",
   "Right-click a ship for more options": "함선을 우클릭하면 메뉴가 열립니다",
   "Got it": "확인",
-  "Right-click a plugin for more options": "플러그인을 우클릭하면 메뉴가 열립니다"
+  "Right-click a plugin for more options": "플러그인을 우클릭하면 메뉴가 열립니다",
+  "編成": "편성",
+  "改装": "개장",
+  "The remodel screen has no sort": "개장 화면에는 정렬이 없습니다"
 }

--- a/i18n/main/ko-KR.json
+++ b/i18n/main/ko-KR.json
@@ -168,5 +168,6 @@
   "The remodel screen has no sort": "개장 화면에는 정렬이 없습니다",
   "装備": "장비",
   "基地航空隊": "기지항공대",
-  "The land base has its own tabs": "기지항공대는 전용 탭으로 좁힙니다"
+  "The land base has its own tabs": "기지항공대는 전용 탭으로 좁힙니다",
+  "The remodel screen has no tag filter": "개장 화면에는 태그 필터가 없습니다"
 }

--- a/i18n/main/ko-KR.json
+++ b/i18n/main/ko-KR.json
@@ -165,5 +165,8 @@
   "Right-click a plugin for more options": "플러그인을 우클릭하면 메뉴가 열립니다",
   "編成": "편성",
   "改装": "개장",
-  "The remodel screen has no sort": "개장 화면에는 정렬이 없습니다"
+  "The remodel screen has no sort": "개장 화면에는 정렬이 없습니다",
+  "装備": "장비",
+  "基地航空隊": "기지항공대",
+  "The land base has its own tabs": "기지항공대는 전용 탭으로 좁힙니다"
 }

--- a/i18n/main/zh-CN.json
+++ b/i18n/main/zh-CN.json
@@ -167,5 +167,8 @@
   "The ex-slot lists every equipment": "补强增设格显示全部装备",
   "Right-click a ship for more options": "右键点击舰娘可打开菜单",
   "Got it": "知道了",
-  "Right-click a plugin for more options": "右键点击插件可打开菜单"
+  "Right-click a plugin for more options": "右键点击插件可打开菜单",
+  "編成": "编成",
+  "改装": "改装",
+  "The remodel screen has no sort": "改装画面没有排序功能"
 }

--- a/i18n/main/zh-CN.json
+++ b/i18n/main/zh-CN.json
@@ -173,5 +173,6 @@
   "The remodel screen has no sort": "改装画面没有排序功能",
   "装備": "装备",
   "基地航空隊": "基地航空队",
-  "The land base has its own tabs": "基地航空队使用专用的分类标签"
+  "The land base has its own tabs": "基地航空队使用专用的分类标签",
+  "The remodel screen has no tag filter": "改装画面没有标签筛选"
 }

--- a/i18n/main/zh-CN.json
+++ b/i18n/main/zh-CN.json
@@ -170,5 +170,8 @@
   "Right-click a plugin for more options": "右键点击插件可打开菜单",
   "編成": "编成",
   "改装": "改装",
-  "The remodel screen has no sort": "改装画面没有排序功能"
+  "The remodel screen has no sort": "改装画面没有排序功能",
+  "装備": "装备",
+  "基地航空隊": "基地航空队",
+  "The land base has its own tabs": "基地航空队使用专用的分类标签"
 }

--- a/i18n/main/zh-TW.json
+++ b/i18n/main/zh-TW.json
@@ -170,5 +170,8 @@
   "Right-click a plugin for more options": "右鍵點擊擴展程式可開啟選單",
   "編成": "編成",
   "改装": "改裝",
-  "The remodel screen has no sort": "改裝畫面沒有排序功能"
+  "The remodel screen has no sort": "改裝畫面沒有排序功能",
+  "装備": "裝備",
+  "基地航空隊": "基地航空隊",
+  "The land base has its own tabs": "基地航空隊使用專用的分類標籤"
 }

--- a/i18n/main/zh-TW.json
+++ b/i18n/main/zh-TW.json
@@ -167,5 +167,8 @@
   "The ex-slot lists every equipment": "補強增設格顯示全部裝備",
   "Right-click a ship for more options": "右鍵點擊艦娘可開啟選單",
   "Got it": "知道了",
-  "Right-click a plugin for more options": "右鍵點擊擴展程式可開啟選單"
+  "Right-click a plugin for more options": "右鍵點擊擴展程式可開啟選單",
+  "編成": "編成",
+  "改装": "改裝",
+  "The remodel screen has no sort": "改裝畫面沒有排序功能"
 }

--- a/i18n/main/zh-TW.json
+++ b/i18n/main/zh-TW.json
@@ -173,5 +173,6 @@
   "The remodel screen has no sort": "改裝畫面沒有排序功能",
   "装備": "裝備",
   "基地航空隊": "基地航空隊",
-  "The land base has its own tabs": "基地航空隊使用專用的分類標籤"
+  "The land base has its own tabs": "基地航空隊使用專用的分類標籤",
+  "The remodel screen has no tag filter": "改裝畫面沒有標籤篩選"
 }

--- a/views/components/etc/global-search/event.ts
+++ b/views/components/etc/global-search/event.ts
@@ -1,8 +1,14 @@
 import { EventEmitter } from 'views/utils/event-emitter'
 
-export type SearchMode = 'ship' | 'equip' | 'airbase'
+/**
+ * The two rosters the panel searches. Each has more than one in-game screen
+ * behind it — 編成 / 改装 for ships, 装備 / 基地航空隊 for equipment — and those
+ * are picked on the second row rather than here, since they share a roster and
+ * differ only in how it is filtered and ordered.
+ */
+export type SearchMode = 'ship' | 'equip'
 
-export const SEARCH_MODES: SearchMode[] = ['ship', 'equip', 'airbase']
+export const SEARCH_MODES: SearchMode[] = ['ship', 'equip']
 
 export const isSearchMode = (value: string): value is SearchMode =>
   (SEARCH_MODES as string[]).includes(value)

--- a/views/components/etc/global-search/index.tsx
+++ b/views/components/etc/global-search/index.tsx
@@ -826,7 +826,11 @@ export const GlobalSearch = () => {
   const noAnimation = !enableTransition
 
   const handleOpen = useCallback((event: SearchOpenEvent) => {
-    if (event.mode) setMode(event.mode)
+    // event.mode is typed as SearchMode, but the emitter is reachable from
+    // untyped plugin code, so a stale 'airbase' (or any other string) has to
+    // be rejected here rather than trusted — same guard changeMode applies to
+    // the segmented control's own onValueChange.
+    if (event.mode && isSearchMode(event.mode)) setMode(event.mode)
     const scope = event.scope
     setScopeRequest((prev) => ({ serial: prev.serial + 1, scope }))
     // Re-opening mid-dismissal cancels it rather than queueing a second cycle.

--- a/views/components/etc/global-search/index.tsx
+++ b/views/components/etc/global-search/index.tsx
@@ -3,6 +3,7 @@ import type {
   EquipEntry,
   EquipListMode,
   EquipListPosition,
+  RemodelPosition,
   SelectorPosition,
   ShipEntry,
   SlotTarget,
@@ -31,6 +32,8 @@ import {
   allShipTabIds,
   buildAirbaseList,
   buildEquipLists,
+  buildRemodelList,
+  buildRemodelPositions,
   buildShipList,
   equipListPositions,
   shipFilterTabs,
@@ -43,6 +46,7 @@ import { getShipLabelStatus, getStatusStyle, selectShipAvatarColor } from 'views
 import {
   constSelector,
   fcdShipTagColorSelector,
+  fleetsSelector,
   inRepairShipsIdSelector,
   mapsSelector,
 } from 'views/utils/selectors'
@@ -173,9 +177,44 @@ const Proficiency = ({ alv }: { alv: number | undefined }) => {
   return <RowALevel className="alv-img" src={`assets/img/airplane/alv${alv}.png`} alt="" />
 }
 
+/**
+ * Which in-game screen's roster the ship list mirrors. 編成 is the 艦船選択
+ * picker this panel was built around; 改装 is the remodel screen, whose ship
+ * list has neither filters nor a sort button — see `buildRemodelList`.
+ */
+type ShipScene = 'organize' | 'remodel'
+
 interface Result<T> {
   entry: T
   position: SelectorPosition | undefined
+}
+
+/** A ship row is numbered by whichever screen's list it came from. */
+interface ShipResult {
+  entry: ShipEntry
+  position: SelectorPosition | RemodelPosition | undefined
+}
+
+/**
+ * The 改装 picker's position, which is a fleet and a slot for anything in a
+ * fleet and a page and row in the その他 tab for everything else.
+ */
+const RemodelPositionTag = ({ position }: { position: RemodelPosition | undefined }) => {
+  const { t } = useTranslation('main')
+  if (!position) return null
+  if (position.kind === 'fleet') {
+    return (
+      <PositionTagEl minimal intent="primary">
+        {t('main:Fleet')} {position.fleet} · {t('main:Row')} {position.index}
+      </PositionTagEl>
+    )
+  }
+  return (
+    <PositionTagEl minimal>
+      {translateCaption('その他')} · {t('main:Page')} {position.page} · {t('main:Row')}{' '}
+      {position.index}
+    </PositionTagEl>
+  )
 }
 
 /**
@@ -193,7 +232,7 @@ const ShipResultRow = ({
   onSearchEquips,
 }: {
   entry: ShipEntry
-  position: SelectorPosition | undefined
+  position: SelectorPosition | RemodelPosition | undefined
   enableAvatar: boolean
   avatarType: string
   shipTagColor: string[]
@@ -243,7 +282,11 @@ const ShipResultRow = ({
       <Tooltip content={t('main:Search equipment for this ship')} position={Position.TOP}>
         <Button small minimal icon="search" onClick={() => onSearchEquips(entry)} />
       </Tooltip>
-      <PositionTag position={position} />
+      {position && 'kind' in position ? (
+        <RemodelPositionTag position={position} />
+      ) : (
+        <PositionTag position={position} />
+      )}
     </ResultRow>
   )
 }
@@ -288,6 +331,7 @@ const GlobalSearchPanel = ({
   const [tabs, setTabs] = useState<number[] | null>(null)
   const [tag, setTag] = useState<ShipTagFilter>('all')
   const [sortKey, setSortKey] = useState<ShipSortKey>(1)
+  const [shipScene, setShipScene] = useState<ShipScene>('organize')
   const [equipCategory, setEquipCategory] = useState(ALL_EQUIPS_CATEGORY)
   const [airbaseTab, setAirbaseTab] = useState(0)
   const [equipScope, setEquipScope] = useState<EquipScope | null>(initialEquipScope ?? null)
@@ -308,6 +352,7 @@ const GlobalSearchPanel = ({
     (state: RootState): string => state.config?.poi?.appearance?.avatarType ?? 'rarity',
   )
   const shipTagColor = useSelector(fcdShipTagColorSelector)
+  const fleets = useSelector(fleetsSelector)
   const inRepairIds = useSelector(inRepairShipsIdSelector)
   const inRepair = useMemo(() => new Set(inRepairIds ?? []), [inRepairIds])
 
@@ -334,15 +379,19 @@ const GlobalSearchPanel = ({
 
   // Positions must come from the *full* list under the current filter, since
   // that is what the in-game picker paginates; the query only hides rows.
-  const shipResults = useMemo((): Result<ShipEntry>[] => {
+  const remodelScene = mode === 'ship' && shipScene === 'remodel'
+
+  const shipResults = useMemo((): ShipResult[] => {
     if (mode !== 'ship') return []
-    const list = buildShipList(
-      shipEntries,
-      { tabs: activeTabs, tag: effectiveTag, sortKey },
-      tables,
-    )
-    const positions = shipPositions(list)
-    const matched: Result<ShipEntry>[] = []
+    // 改装 shows the whole roster in fleet order; none of the 編成 filters
+    // exist on that screen, so none of them are consulted here either.
+    const list = remodelScene
+      ? buildRemodelList(shipEntries, fleets)
+      : buildShipList(shipEntries, { tabs: activeTabs, tag: effectiveTag, sortKey }, tables)
+    const positions: Map<number, SelectorPosition | RemodelPosition> = remodelScene
+      ? buildRemodelPositions(shipEntries, fleets)
+      : shipPositions(list)
+    const matched: ShipResult[] = []
     for (const entry of list) {
       const name = entry.$ship.api_name
       // The reading is matched literally too, for anyone typing kana.
@@ -351,7 +400,7 @@ const GlobalSearchPanel = ({
       if (matched.length >= MAX_RESULTS) break
     }
     return matched
-  }, [mode, shipEntries, activeTabs, effectiveTag, sortKey, query, tables])
+  }, [mode, remodelScene, shipEntries, fleets, activeTabs, effectiveTag, sortKey, query, tables])
 
   // The ex-slot picker has no category tabs in game, so the category filter is
   // pinned to 全装備 (and disabled) while the ex-slot is selected.
@@ -494,6 +543,8 @@ const GlobalSearchPanel = ({
             <FilterSelect
               value={sortKey}
               onSelect={setSortKey}
+              disabled={remodelScene}
+              title={remodelScene ? t('main:The remodel screen has no sort') : undefined}
               width="7em"
               options={SHIP_SORT_KEYS.map((key) => ({
                 value: key,
@@ -504,9 +555,15 @@ const GlobalSearchPanel = ({
             <FilterSelect
               value={tag}
               onSelect={setTag}
-              disabled={!eventActive}
+              disabled={!eventActive || remodelScene}
               width="7em"
-              title={eventActive ? undefined : t('main:Available during events only')}
+              title={
+                remodelScene
+                  ? t('main:The remodel screen has no sort')
+                  : eventActive
+                    ? undefined
+                    : t('main:Available during events only')
+              }
               options={[
                 { value: 'all' as ShipTagFilter, label: t('main:All ships') },
                 { value: 'tagged' as ShipTagFilter, label: t('main:Tagged') },
@@ -539,19 +596,37 @@ const GlobalSearchPanel = ({
 
       {mode === 'ship' && (
         <FilterRow>
+          {/* 改装 has no type tabs, no tag filter and no sort button, so the
+              rest of the ship controls go dead while it is selected. */}
+          <PillControl
+            value={shipScene}
+            onValueChange={(next) => setShipScene(next === 'remodel' ? 'remodel' : 'organize')}
+            options={[
+              { value: 'organize', label: translateCaption('編成') },
+              { value: 'remodel', label: translateCaption('改装') },
+            ]}
+            intent="primary"
+            size="small"
+          />
           <ButtonGroup>
             {shipFilterTabs(tables).map((tab) => (
               <TabButton
                 key={tab.id}
                 small
-                $selected={activeTabs.includes(tab.id)}
+                disabled={remodelScene}
+                $selected={!remodelScene && activeTabs.includes(tab.id)}
                 onClick={() => toggleTab(tab.id)}
               >
                 {translateCaption(tab.name)}
               </TabButton>
             ))}
           </ButtonGroup>
-          <TabButton small $selected={allTabsOn} onClick={toggleAllTabs}>
+          <TabButton
+            small
+            disabled={remodelScene}
+            $selected={!remodelScene && allTabsOn}
+            onClick={toggleAllTabs}
+          >
             {translateCaption('全艦艇')}
           </TabButton>
           <Tag minimal>{t('main:{{count}} shown', { count: results.length })}</Tag>

--- a/views/components/etc/global-search/index.tsx
+++ b/views/components/etc/global-search/index.tsx
@@ -217,7 +217,7 @@ const RemodelPositionTag = ({ position }: { position: RemodelPosition | undefine
     )
   }
   return (
-    <PositionTagEl minimal>
+    <PositionTagEl minimal $wide>
       {translateCaption('その他')} · {t('main:Page')} {position.page} · {t('main:Row')}{' '}
       {position.index}
     </PositionTagEl>

--- a/views/components/etc/global-search/index.tsx
+++ b/views/components/etc/global-search/index.tsx
@@ -580,7 +580,7 @@ const GlobalSearchPanel = ({
               width="7em"
               title={
                 remodelScene
-                  ? t('main:The remodel screen has no sort')
+                  ? t('main:The remodel screen has no tag filter')
                   : eventActive
                     ? undefined
                     : t('main:Available during events only')

--- a/views/components/etc/global-search/index.tsx
+++ b/views/components/etc/global-search/index.tsx
@@ -184,6 +184,13 @@ const Proficiency = ({ alv }: { alv: number | undefined }) => {
  */
 type ShipScene = 'organize' | 'remodel'
 
+/**
+ * The same split on the equipment side: 装備 is the ship-equipment picker, 基地
+ *航空隊 the land base squadron picker, which draws from the same inventory but
+ * has its own tabs, its own ordering and a shorter page.
+ */
+type EquipScene = 'equip' | 'airbase'
+
 interface Result<T> {
   entry: T
   position: SelectorPosition | undefined
@@ -333,6 +340,7 @@ const GlobalSearchPanel = ({
   const [sortKey, setSortKey] = useState<ShipSortKey>(1)
   const [shipScene, setShipScene] = useState<ShipScene>('organize')
   const [equipCategory, setEquipCategory] = useState(ALL_EQUIPS_CATEGORY)
+  const [equipScene, setEquipScene] = useState<EquipScene>('equip')
   const [airbaseTab, setAirbaseTab] = useState(0)
   const [equipScope, setEquipScope] = useState<EquipScope | null>(initialEquipScope ?? null)
   const [equipSlot, setEquipSlot] = useState<SlotTarget | null>(null)
@@ -402,13 +410,15 @@ const GlobalSearchPanel = ({
     return matched
   }, [mode, remodelScene, shipEntries, fleets, activeTabs, effectiveTag, sortKey, query, tables])
 
+  const airbaseScene = mode === 'equip' && equipScene === 'airbase'
+
   // The ex-slot picker has no category tabs in game, so the category filter is
   // pinned to 全装備 (and disabled) while the ex-slot is selected.
   const slotLocksCategory = equipScope != null && equipSlot === EXTRA_SLOT
   const effectiveCategory = slotLocksCategory ? ALL_EQUIPS_CATEGORY : equipCategory
 
   const equipResults = useMemo((): EquipResult[] => {
-    if (mode !== 'equip') return []
+    if (mode !== 'equip' || airbaseScene) return []
     const lists = buildEquipLists(
       equipEntries,
       {
@@ -430,10 +440,20 @@ const GlobalSearchPanel = ({
       if (matched.length >= MAX_RESULTS) break
     }
     return matched
-  }, [mode, equipEntries, effectiveCategory, equipScope, equipSlot, constState, query, tables])
+  }, [
+    mode,
+    airbaseScene,
+    equipEntries,
+    effectiveCategory,
+    equipScope,
+    equipSlot,
+    constState,
+    query,
+    tables,
+  ])
 
   const airbaseResults = useMemo((): Result<EquipEntry>[] => {
-    if (mode !== 'airbase') return []
+    if (!airbaseScene) return []
     const list = buildAirbaseList(equipEntries, { tab: airbaseTab }, tables)
     const positions = airbasePositions(list)
     const matched: Result<EquipEntry>[] = []
@@ -443,7 +463,7 @@ const GlobalSearchPanel = ({
       if (matched.length >= MAX_RESULTS) break
     }
     return matched
-  }, [mode, equipEntries, airbaseTab, tables, query])
+  }, [airbaseScene, equipEntries, airbaseTab, tables, query])
 
   const toggleTab = useCallback(
     (id: number) =>
@@ -482,12 +502,14 @@ const GlobalSearchPanel = ({
     })
     setEquipSlot(null)
     setEquipCategory(ALL_EQUIPS_CATEGORY)
+    // A ship scope means the ship-equipment picker, never the land base.
+    setEquipScene('equip')
     setQuery('')
     setMode('equip')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const results = mode === 'ship' ? shipResults : mode === 'equip' ? equipResults : airbaseResults
+  const results = mode === 'ship' ? shipResults : airbaseScene ? airbaseResults : equipResults
   const allTabsOn = activeTabs.length === allTabIds.length
 
   return (
@@ -503,7 +525,6 @@ const GlobalSearchPanel = ({
           options={[
             { value: 'ship', label: t('main:Ships') },
             { value: 'equip', label: t('main:Equip') },
-            { value: 'airbase', label: t('main:Land base') },
           ]}
           intent="primary"
         />
@@ -576,8 +597,14 @@ const GlobalSearchPanel = ({
           <FilterSelect
             value={effectiveCategory}
             onSelect={setEquipCategory}
-            disabled={slotLocksCategory}
-            title={slotLocksCategory ? t('main:The ex-slot lists every equipment') : undefined}
+            disabled={slotLocksCategory || airbaseScene}
+            title={
+              airbaseScene
+                ? t('main:The land base has its own tabs')
+                : slotLocksCategory
+                  ? t('main:The ex-slot lists every equipment')
+                  : undefined
+            }
             width="13em"
             options={tables.equipFilterCategories.map((category) => ({
               value: category.id,
@@ -636,7 +663,7 @@ const GlobalSearchPanel = ({
       {/* A few ships bar particular equipment from particular slots, and the
           ex-slot has rules of its own, so the list is only exact once a slot is
           named. "Any" keeps the whole-ship view the scope opens on. */}
-      {mode === 'equip' && equipScope && (
+      {mode === 'equip' && !airbaseScene && equipScope && (
         <ScopeBar>
           <span>
             {t('main:Equippable by {{name}}', {
@@ -672,31 +699,38 @@ const GlobalSearchPanel = ({
         </ScopeBar>
       )}
 
-      {mode === 'equip' && !equipScope && (
+      {mode === 'equip' && (airbaseScene || !equipScope) && (
         <FilterRow>
-          <Tag minimal>{t('main:{{count}} shown', { count: results.length })}</Tag>
-        </FilterRow>
-      )}
-
-      {/* One tab at a time, as in game — a radio group rather than the ship
-          strip's independent toggles. On its own row: five CJK captions do not
-          share a line with the search box. */}
-      {mode === 'airbase' && (
-        <FilterRow>
+          {/* 装備 and 基地航空隊 draw from the same inventory but are separate
+              screens in game, with their own tabs and their own ordering. */}
           <PillControl
-            value={String(airbaseTab)}
-            onValueChange={(next) => {
-              const id = Number(next)
-              if (Number.isFinite(id)) setAirbaseTab(id)
-            }}
-            options={tables.airbaseFilterTabs.map((tab) => ({
-              value: String(tab.id),
-              label: translateCaption(tab.name),
-              icon: <PillIcon slotitemId={tab.icon} alt="" />,
-            }))}
+            value={equipScene}
+            onValueChange={(next) => setEquipScene(next === 'airbase' ? 'airbase' : 'equip')}
+            options={[
+              { value: 'equip', label: translateCaption('装備') },
+              { value: 'airbase', label: translateCaption('基地航空隊') },
+            ]}
             intent="primary"
             size="small"
           />
+          {/* One tab at a time, as in game — a radio group rather than the ship
+              strip's independent toggles. */}
+          {airbaseScene && (
+            <PillControl
+              value={String(airbaseTab)}
+              onValueChange={(next) => {
+                const id = Number(next)
+                if (Number.isFinite(id)) setAirbaseTab(id)
+              }}
+              options={tables.airbaseFilterTabs.map((tab) => ({
+                value: String(tab.id),
+                label: translateCaption(tab.name),
+                icon: <PillIcon slotitemId={tab.icon} alt="" />,
+              }))}
+              intent="primary"
+              size="small"
+            />
+          )}
           <Tag minimal>{t('main:{{count}} shown', { count: results.length })}</Tag>
         </FilterRow>
       )}
@@ -717,7 +751,7 @@ const GlobalSearchPanel = ({
               onSearchEquips={searchEquipsFor}
             />
           ))
-        ) : mode === 'equip' ? (
+        ) : !airbaseScene ? (
           equipResults.map(({ entry, position }) => (
             <ResultRow key={entry.equip.api_id}>
               <RowIcon slotitemId={entry.$equip.api_type?.[3]} alt="" />

--- a/views/components/etc/global-search/styles.ts
+++ b/views/components/etc/global-search/styles.ts
@@ -368,20 +368,23 @@ export const Meta = styled.div`
 
 /**
  * Fixed width, like Meta above — a tag that resized to its own content made
- * neighboring rows' icons drift out of column. 16em covers the widest tag any
- * mode produces with margin: the remodel scene's その他 case carries three
- * segments ("Other · Page 10 · Row 10") where every other mode carries two,
- * and that three-segment form is the longest in every shipped locale (checked
- * en/ja/zh-CN/zh-TW/ko — full-width CJK glyphs cost more per character than
- * they save by being shorter words, so no locale is meaningfully narrower). A
- * tag that still overflows this — three-digit page numbers, which only a very
- * large single-category inventory would reach — degrades to Blueprint's
- * built-in ellipsis rather than breaking the row.
+ * neighboring rows' icons drift out of column. Two segments ("Page 10 · Row
+ * 10", "Fleet 4 · Row 6") is what every mode but one shows, and 9.5em is the
+ * long-standing width that already fit that case comfortably in every shipped
+ * locale, so it stays the default.
+ *
+ * `$wide` is for the one exception: the remodel scene's その他 tag carries a
+ * third segment ("Other · Page 10 · Row 10"), which is the longest tag any
+ * mode produces in every shipped locale (checked en/ja/zh-CN/zh-TW/ko —
+ * full-width CJK glyphs cost more per character than they save by being
+ * shorter words). A tag that still overflows either width — three-digit page
+ * numbers, which only a very large single-category inventory would reach —
+ * degrades to Blueprint's built-in ellipsis rather than breaking the row.
  */
-export const PositionTagEl = styled(Tag)`
+export const PositionTagEl = styled(Tag)<{ $wide?: boolean }>`
   && {
     flex: 0 0 auto;
-    width: 16em;
+    width: ${({ $wide }) => ($wide ? '16em' : '9.5em')};
     justify-content: center;
     text-align: center;
   }

--- a/views/components/etc/global-search/styles.ts
+++ b/views/components/etc/global-search/styles.ts
@@ -366,10 +366,17 @@ export const Meta = styled.div`
   opacity: 0.75;
 `
 
+/**
+ * Sized to its content rather than a fixed width: the remodel scene's その他
+ * tag carries three segments ("Other · Page 10 · Row 10") where every other
+ * mode carries two, and a fixed width sized for the short case clips the long
+ * one — worse once any of the three segments runs long in translation. The
+ * ship tile and name column absorb the difference; both already shrink.
+ */
 export const PositionTagEl = styled(Tag)`
   && {
     flex: 0 0 auto;
-    width: 9.5em;
+    white-space: nowrap;
     justify-content: center;
     text-align: center;
   }

--- a/views/components/etc/global-search/styles.ts
+++ b/views/components/etc/global-search/styles.ts
@@ -367,16 +367,21 @@ export const Meta = styled.div`
 `
 
 /**
- * Sized to its content rather than a fixed width: the remodel scene's その他
- * tag carries three segments ("Other · Page 10 · Row 10") where every other
- * mode carries two, and a fixed width sized for the short case clips the long
- * one — worse once any of the three segments runs long in translation. The
- * ship tile and name column absorb the difference; both already shrink.
+ * Fixed width, like Meta above — a tag that resized to its own content made
+ * neighboring rows' icons drift out of column. 16em covers the widest tag any
+ * mode produces with margin: the remodel scene's その他 case carries three
+ * segments ("Other · Page 10 · Row 10") where every other mode carries two,
+ * and that three-segment form is the longest in every shipped locale (checked
+ * en/ja/zh-CN/zh-TW/ko — full-width CJK glyphs cost more per character than
+ * they save by being shorter words, so no locale is meaningfully narrower). A
+ * tag that still overflows this — three-digit page numbers, which only a very
+ * large single-category inventory would reach — degrades to Blueprint's
+ * built-in ellipsis rather than breaking the row.
  */
 export const PositionTagEl = styled(Tag)`
   && {
     flex: 0 0 auto;
-    white-space: nowrap;
+    width: 16em;
     justify-content: center;
     text-align: center;
   }

--- a/views/utils/game-selector/__tests__/game-selector.spec.ts
+++ b/views/utils/game-selector/__tests__/game-selector.spec.ts
@@ -15,6 +15,8 @@ import {
   allShipTabIds,
   buildEquipList,
   buildEquipLists,
+  buildRemodelList,
+  buildRemodelPositions,
   buildShipList,
   compareEquips,
   compareShips,
@@ -26,6 +28,7 @@ import {
   worldOf,
   positionOf,
   ROWS_PER_PAGE,
+  REMODEL_OTHER_SORT_KEY,
   SHIP_SORT_KEYS,
   shipPositions,
   sortShips,
@@ -632,5 +635,83 @@ describe('an equipment category that accepts nothing', () => {
 
   spec('but 全装備 still means everything', () => {
     expect(buildEquipList(allEquipEntries, equipFilter())).toHaveLength(allEquipEntries.length)
+  })
+})
+
+/**
+ * The 改装 roster: `SelectShipView` shows a tab per fleet and one paginated
+ * その他 tab for everything not in a fleet, the latter ordered by
+ * `ShipUtil.sort(list, 1)` reversed.
+ */
+describe('the 改装 roster', () => {
+  // Two fleets off the front of the fixture, with a gap where the game writes
+  // -1 for an empty slot.
+  const rosterIds = allShipEntries.map((entry) => entry.ship.api_id)
+  const fleets = [
+    { api_ship: [rosterIds[3], rosterIds[7], -1, rosterIds[1]] },
+    { api_ship: [rosterIds[10], -1, -1, -1, -1, -1] },
+  ]
+
+  spec('lists every fleet in slot order before anything else', () => {
+    const list = buildRemodelList(allShipEntries, fleets)
+    expect(list.slice(0, 4).map((entry) => entry.ship.api_id)).toEqual([
+      rosterIds[3],
+      rosterIds[7],
+      rosterIds[1],
+      rosterIds[10],
+    ])
+  })
+
+  spec('orders the rest by level ascending, as the その他 tab does', () => {
+    const list = buildRemodelList(allShipEntries, fleets)
+    const others = list.slice(4)
+    const levels = others.map((entry) => entry.ship.api_lv ?? 0)
+    expect([...levels].sort((a, b) => a - b)).toEqual(levels)
+    // Same ordering the game reaches by sorting on key 1 and reversing.
+    const expected = sortShips(
+      allShipEntries.filter(
+        (entry) => !fleets.some((fleet) => fleet.api_ship.includes(entry.ship.api_id)),
+      ),
+      REMODEL_OTHER_SORT_KEY,
+    )
+    expect(others.map((entry) => entry.ship.api_id)).toEqual(
+      expected.map((entry) => entry.ship.api_id),
+    )
+  })
+
+  spec('holds the whole roster exactly once', () => {
+    const list = buildRemodelList(allShipEntries, fleets)
+    expect(list).toHaveLength(allShipEntries.length)
+    expect(new Set(list.map((entry) => entry.ship.api_id)).size).toBe(allShipEntries.length)
+  })
+
+  spec('numbers fleet ships by fleet and slot, skipping empty slots', () => {
+    const positions = buildRemodelPositions(allShipEntries, fleets)
+    expect(positions.get(rosterIds[3])).toEqual({ kind: 'fleet', fleet: 1, index: 1 })
+    expect(positions.get(rosterIds[7])).toEqual({ kind: 'fleet', fleet: 1, index: 2 })
+    // The -1 slot is skipped rather than counted, so this is 3 and not 4.
+    expect(positions.get(rosterIds[1])).toEqual({ kind: 'fleet', fleet: 1, index: 3 })
+    expect(positions.get(rosterIds[10])).toEqual({ kind: 'fleet', fleet: 2, index: 1 })
+  })
+
+  spec('paginates the その他 tab by ten from its own first page', () => {
+    const positions = buildRemodelPositions(allShipEntries, fleets)
+    const others = buildRemodelList(allShipEntries, fleets).slice(4)
+    const first = positions.get(others[0].ship.api_id)
+    const eleventh = positions.get(others[ROWS_PER_PAGE].ship.api_id)
+    expect(first).toEqual({ kind: 'other', page: 1, index: 1, offset: 0 })
+    expect(eleventh).toEqual({
+      kind: 'other',
+      page: 2,
+      index: 1,
+      offset: ROWS_PER_PAGE,
+    })
+  })
+
+  spec('treats a missing fleet list as an empty roster of fleets', () => {
+    const list = buildRemodelList(allShipEntries, undefined)
+    expect(list).toHaveLength(allShipEntries.length)
+    const positions = buildRemodelPositions(allShipEntries, undefined)
+    expect([...positions.values()].every((position) => position.kind === 'other')).toBe(true)
   })
 })

--- a/views/utils/game-selector/ship.ts
+++ b/views/utils/game-selector/ship.ts
@@ -5,7 +5,7 @@ import type { Ship } from 'views/redux/info/ships'
 import type { SelectorTables, ShipFilterTab } from './tables'
 
 import { getSelectorTables } from './tables'
-import { positionOf, type SelectorPosition } from './types'
+import { positionOf, type RemodelPosition, type SelectorPosition } from './types'
 
 /**
  * Filter tabs of the in-game 艦船選択 picker, in on-screen order.
@@ -149,6 +149,71 @@ export const buildShipList = (
 
 export const shipPositions = (list: ShipEntry[]): Map<number, SelectorPosition> =>
   new Map(list.map((entry, offset) => [entry.ship.api_id, positionOf(offset)]))
+
+/** `ShipUtil.sort(list, 1)` reversed: level ascending. */
+export const REMODEL_OTHER_SORT_KEY = 0
+
+/**
+ * The 改装 ship picker, which orders its roster quite differently from 編成.
+ *
+ * `SelectShipView` has no filters and no sort button: one tab per fleet showing
+ * that fleet in slot order, and an その他 tab holding everything not in a fleet.
+ * That tab is `_getOtherShipData` — `ship.getAllOther()` sorted by key 1 and
+ * then reversed, which is key 0 here — and it paginates by ten like every other
+ * list in the game.
+ */
+export const buildRemodelPositions = (
+  entries: ShipEntry[],
+  fleets: readonly { api_ship: number[] }[] | undefined,
+): Map<number, RemodelPosition> => {
+  const positions = new Map<number, RemodelPosition>()
+  const inFleet = new Set<number>()
+  ;(fleets ?? []).forEach((fleet, fleetIndex) => {
+    let slot = 0
+    for (const shipId of fleet?.api_ship ?? []) {
+      // -1 is an empty slot, which the game skips rather than numbers.
+      if (shipId === -1) continue
+      inFleet.add(shipId)
+      positions.set(shipId, { kind: 'fleet', fleet: fleetIndex + 1, index: ++slot })
+    }
+  })
+
+  const others = sortShips(
+    entries.filter((entry) => !inFleet.has(entry.ship.api_id)),
+    REMODEL_OTHER_SORT_KEY,
+  )
+  others.forEach((entry, offset) =>
+    positions.set(entry.ship.api_id, { kind: 'other', ...positionOf(offset) }),
+  )
+  return positions
+}
+
+/**
+ * The 改装 roster in on-screen order: every fleet in turn, then the rest.
+ */
+export const buildRemodelList = (
+  entries: ShipEntry[],
+  fleets: readonly { api_ship: number[] }[] | undefined,
+): ShipEntry[] => {
+  const byId = new Map(entries.map((entry) => [entry.ship.api_id, entry]))
+  const list: ShipEntry[] = []
+  const taken = new Set<number>()
+  for (const fleet of fleets ?? []) {
+    for (const shipId of fleet?.api_ship ?? []) {
+      const entry = shipId !== -1 ? byId.get(shipId) : undefined
+      if (!entry || taken.has(shipId)) continue
+      taken.add(shipId)
+      list.push(entry)
+    }
+  }
+  return [
+    ...list,
+    ...sortShips(
+      entries.filter((entry) => !taken.has(entry.ship.api_id)),
+      REMODEL_OTHER_SORT_KEY,
+    ),
+  ]
+}
 
 /** Standard worlds are 1–7; anything past this is an event world. */
 const LAST_NORMAL_WORLD = 10

--- a/views/utils/game-selector/types.ts
+++ b/views/utils/game-selector/types.ts
@@ -22,3 +22,12 @@ export const positionOf = (offset: number, perPage = ROWS_PER_PAGE): SelectorPos
   index: (offset % perPage) + 1,
   offset,
 })
+
+/**
+ * Where a ship sits in the 改装 picker, which is not one paginated list: a tab
+ * per fleet showing that fleet whole, plus a paginated その他 tab for everything
+ * not in a fleet.
+ */
+export type RemodelPosition =
+  | { kind: 'fleet'; fleet: number; index: number }
+  | ({ kind: 'other' } & SelectorPosition)


### PR DESCRIPTION
Follow-up to #2703. The panel's top strip listed three modes, but 基地航空隊 is
not a third roster — it is a second *screen* over the equipment roster, the way
改装 is a second screen over the ship roster. Both now sit on the second row as
a scene switch, and the top strip is just 艦娘 / 装備.

| mode | scene switch | what goes dead in the second scene |
|---|---|---|
| 艦娘 | 編成 / 改装 | sort select, tag select, type tabs, 全艦艇 |
| 装備 | 装備 / 基地航空隊 | equipment category select |

## The 改装 roster

The remodel screen orders its ships quite differently from 編成, and the search
results now mirror it. Ported from `SelectShipView`:

```js
_getOtherShipData() {
  const ct = model.ship.getAllOther()   // every ship not in any deck
  ShipUtil.sort(ct, 1)                  // level descending
  return ct.reverse()                   // → level ascending
}
```

That screen has no filter tabs and no sort button at all: a tab per fleet
showing that fleet whole, plus one paginated その他 tab for everything else.

Note that `sort(…, 1).reverse()` is not the same as an ascending comparator —
reversing a stable sort flips the tie-breaks too, so `sortNo` and `memID` come
out descending. That is exactly the existing sort key 0, already ported and
documented as "the mirror of key 1, used by scenes other than 編成"; it is now
named `REMODEL_OTHER_SORT_KEY` and reused rather than reimplemented.

Because that screen is not one paginated list, a page/row number would be wrong
for fleet ships. `RemodelPosition` is a union: fleet ships read as **Fleet 1 ·
Row 3**, everything else as **Others · Page 2 · Row 1**, numbered from the その他
tab's own first page. Empty fleet slots are `-1` in `api_ship` and the game
skips rather than numbers them, so a fleet holding ships in slots 1, 2 and 4
reports them as rows 1, 2, 3.

## The land base

Same inventory, same rows, same ordering — only where you reach it moved. Under
基地航空隊 the category dropdown disables with a tooltip (the land base has its
own five tabs, now on the same row as the scene switch rather than a row of
their own) and the per-ship scope bar hides, since a land base has no ship to be
scoped to. The scope itself is preserved, so switching back to 装備 restores it.
`searchEquipsFor` resets the scene to 装備, so right-clicking a ship while on the
land base list lands on her equipment rather than a squadron list that ignores
the scope.

`SearchMode` drops to `'ship' | 'equip'`. Nothing passed `'airbase'` through the
open event, so no caller changed.

## Testing

`npm run typecheck` clean, `npm run lint:js` clean, `npx jest` 410/410 across 37
suites. game-selector goes from 117 to 124 specs: fleet-then-others ordering, the
level-ascending tail matched against `sortShips(…, REMODEL_OTHER_SORT_KEY)`, the
`-1` slot skip, その他 pagination, and the no-fleets case.

The land base list builders are untouched, so the change there is routing and
layout only and carries no new tests.

Not visually verified in a running app. The second row is the busiest it has
been, so it is worth a look at a narrow panel width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
