### PR TITLE
fix(window): stop kangame resize loop on Windows

### DIFF
--- a/views/kan-game-window-wrapper.tsx
+++ b/views/kan-game-window-wrapper.tsx
@@ -165,12 +165,12 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
   const currentWindowRef = useRef<Electron.BrowserWindow | null>(null)
   const unwatchBoundsRef = useRef<(() => void) | undefined>(undefined)
   const kangameContainerRef = useRef<HTMLDivElement>(null)
-  const windowsManualResizePendingRef = useRef(false)
+  const windowsManualResizeActiveRef = useRef(false)
   const windowsResizeCorrectionRef = useRef<WindowsResizeCorrection | null>(null)
   const windowsResizeStateTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>()
 
   const clearWindowsResizeState = useCallback(() => {
-    windowsManualResizePendingRef.current = false
+    windowsManualResizeActiveRef.current = false
     windowsResizeCorrectionRef.current = null
     if (windowsResizeStateTimeoutRef.current) {
       clearTimeout(windowsResizeStateTimeoutRef.current)
@@ -298,9 +298,8 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
         BrowserWindow.getAllWindows().find((a) =>
           a.webContents.getURL().endsWith('index-plugin.html?kangame'),
         ) ?? null
-      // Maximized / fullscreen state is deliberately not restored here: this
-      // window is aspect-ratio locked and the resize handler below forces its
-      // content size, which drops it right back out of the maximized state.
+      // Maximized / fullscreen state is deliberately not restored here. They
+      // remain available as transient presentation states during this session.
       curWindow?.once('ready-to-show', () => {
         curWindow.show()
       })
@@ -323,17 +322,85 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
         })
       }
 
-      // `will-resize` is emitted only for manual resizes. Programmatic
-      // setContentSize calls do not reopen this gate, which prevents the
-      // frameless Windows inset from feeding a resize back into itself.
+      // Windows starts a correction only from explicit external events. Resize
+      // events caused by setContentSize can only advance an existing immutable
+      // target, which prevents the frameless inset from feeding a new target
+      // back into itself.
       // https://github.com/electron/electron/issues/51679
       const handleWillResize = () => {
-        windowsResizeCorrectionRef.current = null
-        windowsManualResizePendingRef.current = true
+        clearWindowsResizeState()
+        windowsManualResizeActiveRef.current = true
+      }
+
+      const startWindowsResizeCorrection = () => {
+        if (
+          !curWindow ||
+          !extWindow ||
+          windowsManualResizeActiveRef.current ||
+          windowsResizeCorrectionRef.current ||
+          curWindow.isMaximized() ||
+          curWindow.isFullScreen()
+        ) {
+          return
+        }
+        const target = calculateKangameContentSize(
+          extWindow.innerWidth,
+          latestZoom.current,
+          getYOffset(),
+        )
+        const actual = {
+          width: Math.round(extWindow.innerWidth * latestZoom.current),
+          height: Math.round(extWindow.innerHeight * latestZoom.current),
+        }
+        if (!calculateCompensatedContentSize(target, actual, target)) {
+          clearWindowsResizeState()
+          return
+        }
+        windowsResizeCorrectionRef.current = {
+          attempts: 0,
+          requested: target,
+          target,
+        }
+        curWindow.setContentSize(target.width, target.height)
         expireWindowsResizeState()
       }
+
+      const scheduleWindowsResizeCorrection = debounce(startWindowsResizeCorrection, 200)
+
+      const handleResized = () => {
+        if (!windowsManualResizeActiveRef.current) return
+        windowsManualResizeActiveRef.current = false
+        scheduleWindowsResizeCorrection()
+      }
+
+      const handlePresentationModeEntered = () => {
+        scheduleWindowsResizeCorrection.cancel()
+        clearWindowsResizeState()
+      }
+
+      const handleDisplayMetricsChanged = (
+        _event: Electron.Event,
+        display: Electron.Display,
+        changedMetrics: string[],
+      ) => {
+        if (
+          !curWindow ||
+          (!changedMetrics.includes('scaleFactor') && !changedMetrics.includes('workArea')) ||
+          screen.getDisplayMatching(curWindow.getBounds()).id !== display.id
+        ) {
+          return
+        }
+        scheduleWindowsResizeCorrection()
+      }
+
       if (process.platform === 'win32') {
         curWindow?.on('will-resize', handleWillResize)
+        curWindow?.on('resized', handleResized)
+        curWindow?.on('maximize', handlePresentationModeEntered)
+        curWindow?.on('enter-full-screen', handlePresentationModeEntered)
+        curWindow?.on('unmaximize', scheduleWindowsResizeCorrection)
+        curWindow?.on('leave-full-screen', scheduleWindowsResizeCorrection)
+        screen.on('display-metrics-changed', handleDisplayMetricsChanged)
       }
 
       const handleResize = debounce(() => {
@@ -344,48 +411,37 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
             getYOffset(),
           )
           curWindow?.setContentSize(target.width, target.height)
-        } else if (process.platform === 'win32' && curWindow && extWindow) {
-          if (windowsManualResizePendingRef.current) {
-            const target = calculateKangameContentSize(
-              extWindow.innerWidth,
-              latestZoom.current,
-              getYOffset(),
-            )
-            windowsManualResizePendingRef.current = false
+        } else if (
+          process.platform === 'win32' &&
+          curWindow &&
+          extWindow &&
+          windowsResizeCorrectionRef.current
+        ) {
+          // Keep the original correction target immutable. Electron may
+          // subtract a DPI-scaled frame inset from the resulting viewport,
+          // so compensate the measured error without turning that smaller
+          // viewport into the next target. The retry cap guarantees that an
+          // unexpected platform response can never recreate the old loop.
+          const correction = windowsResizeCorrectionRef.current
+          const actual = {
+            width: Math.round(extWindow.innerWidth * latestZoom.current),
+            height: Math.round(extWindow.innerHeight * latestZoom.current),
+          }
+          const compensated = calculateCompensatedContentSize(
+            correction.target,
+            actual,
+            correction.requested,
+          )
+          if (!compensated || correction.attempts >= WINDOWS_RESIZE_CORRECTION_LIMIT) {
+            clearWindowsResizeState()
+          } else {
             windowsResizeCorrectionRef.current = {
-              attempts: 0,
-              requested: target,
-              target,
+              ...correction,
+              attempts: correction.attempts + 1,
+              requested: compensated,
             }
-            curWindow.setContentSize(target.width, target.height)
+            curWindow.setContentSize(compensated.width, compensated.height)
             expireWindowsResizeState()
-          } else if (windowsResizeCorrectionRef.current) {
-            // Keep the original manual-resize target immutable. Electron may
-            // subtract a DPI-scaled frame inset from the resulting viewport,
-            // so compensate the measured error without turning that smaller
-            // viewport into the next target. The retry cap guarantees that an
-            // unexpected platform response can never recreate the old loop.
-            const correction = windowsResizeCorrectionRef.current
-            const actual = {
-              width: Math.round(extWindow.innerWidth * latestZoom.current),
-              height: Math.round(extWindow.innerHeight * latestZoom.current),
-            }
-            const compensated = calculateCompensatedContentSize(
-              correction.target,
-              actual,
-              correction.requested,
-            )
-            if (!compensated || correction.attempts >= WINDOWS_RESIZE_CORRECTION_LIMIT) {
-              clearWindowsResizeState()
-            } else {
-              windowsResizeCorrectionRef.current = {
-                ...correction,
-                attempts: correction.attempts + 1,
-                requested: compensated,
-              }
-              curWindow.setContentSize(compensated.width, compensated.height)
-              expireWindowsResizeState()
-            }
           }
         }
         getStore('layout.webview.ref')?.executeJavaScript('window.align()')
@@ -399,7 +455,14 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
       extWindow?.addEventListener('resize', handleResize)
       cleanupResizeHandlers = () => {
         curWindow?.off('will-resize', handleWillResize)
+        curWindow?.off('resized', handleResized)
+        curWindow?.off('maximize', handlePresentationModeEntered)
+        curWindow?.off('enter-full-screen', handlePresentationModeEntered)
+        curWindow?.off('unmaximize', scheduleWindowsResizeCorrection)
+        curWindow?.off('leave-full-screen', scheduleWindowsResizeCorrection)
+        screen.off('display-metrics-changed', handleDisplayMetricsChanged)
         extWindow.removeEventListener('resize', handleResize)
+        scheduleWindowsResizeCorrection.cancel()
         handleResize.cancel()
       }
 
@@ -439,8 +502,8 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
       handleWebviewPreloadHack(curWindow!.webContents.id)
 
       if (curWindow) {
-        // Only the geometry is kept: the maximized / fullscreen flags can never be
-        // honored for this window, so persisting them would be dead config
+        // Persist normal geometry only; maximized / fullscreen are transient
+        // presentation states for the isolated game window.
         unwatchBoundsRef.current = watchWindowBounds(
           curWindow,
           ({ isMaximized: _isMaximized, isFullScreen: _isFullScreen, ...bounds }) => {

--- a/views/kan-game-window-wrapper.tsx
+++ b/views/kan-game-window-wrapper.tsx
@@ -283,7 +283,12 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
       extWindow?.addEventListener(
         'resize',
         debounce(() => {
-          if (process.platform !== 'darwin') {
+          // setAspectRatio above already constrains native resizes on Windows.
+          // Electron 41.2.1+ can subtract the frameless thick-frame insets when
+          // setContentSize is called, so feeding innerWidth back into it starts a
+          // resize loop that repeatedly shrinks the window at high DPI.
+          // https://github.com/electron/electron/issues/51679
+          if (process.platform === 'linux') {
             curWindow?.setContentSize(
               Math.round(extWindow.innerWidth * latestZoom.current),
               Math.round(((extWindow.innerWidth / 1200) * 720 + getYOffset()) * latestZoom.current),

--- a/views/kan-game-window-wrapper.tsx
+++ b/views/kan-game-window-wrapper.tsx
@@ -19,6 +19,11 @@ import {
   createLayoutWebviewWindowUseFixedResolutionAction,
   createLayoutWebviewSizeAction,
 } from 'views/redux/actions/layout'
+import {
+  calculateCompensatedContentSize,
+  calculateKangameContentSize,
+  type ContentSize,
+} from 'views/utils/kangame-window-size'
 import { fileUrl, loadScript } from 'views/utils/tools'
 
 import { loadStyle } from './env-parts/theme'
@@ -39,6 +44,15 @@ interface WindowRect {
   width: number
   height: number
 }
+
+interface WindowsResizeCorrection {
+  attempts: number
+  requested: ContentSize
+  target: ContentSize
+}
+
+const WINDOWS_RESIZE_CORRECTION_LIMIT = 2
+const WINDOWS_RESIZE_STATE_TIMEOUT = 2000
 
 const getPluginWindowRect = (): WindowRect => {
   const defaultRect: WindowRect = { width: 1200, height: 780 }
@@ -151,6 +165,28 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
   const currentWindowRef = useRef<Electron.BrowserWindow | null>(null)
   const unwatchBoundsRef = useRef<(() => void) | undefined>(undefined)
   const kangameContainerRef = useRef<HTMLDivElement>(null)
+  const windowsManualResizePendingRef = useRef(false)
+  const windowsResizeCorrectionRef = useRef<WindowsResizeCorrection | null>(null)
+  const windowsResizeStateTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+
+  const clearWindowsResizeState = useCallback(() => {
+    windowsManualResizePendingRef.current = false
+    windowsResizeCorrectionRef.current = null
+    if (windowsResizeStateTimeoutRef.current) {
+      clearTimeout(windowsResizeStateTimeoutRef.current)
+      windowsResizeStateTimeoutRef.current = undefined
+    }
+  }, [])
+
+  const expireWindowsResizeState = useCallback(() => {
+    if (windowsResizeStateTimeoutRef.current) {
+      clearTimeout(windowsResizeStateTimeoutRef.current)
+    }
+    windowsResizeStateTimeoutRef.current = setTimeout(
+      clearWindowsResizeState,
+      WINDOWS_RESIZE_STATE_TIMEOUT,
+    )
+  }, [clearWindowsResizeState])
 
   // Latest-value refs: allow effects to read current values without becoming
   // reactive to them (avoids unintended cross-effect triggers).
@@ -207,6 +243,7 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
         checkBrowserWindowExistence() &&
         currentWindowRef.current?.webContents
       ) {
+        clearWindowsResizeState()
         const [width, height] = currentWindowRef.current.getContentSize()
         currentWindowRef.current.setContentSize(width - 10, height - 10)
         currentWindowRef.current.setContentSize(width, height)
@@ -214,7 +251,7 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
         forceSyncZoom()
       }
     },
-    [checkBrowserWindowExistence, forceSyncZoom],
+    [checkBrowserWindowExistence, clearWindowsResizeState, forceSyncZoom],
   )
 
   // Keep a ref so the mount effect below can read the initial value at open time
@@ -255,6 +292,7 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
     externalWindowRef.current = extWindow
     windowRefsRef.current.externalWindow = extWindow
 
+    let cleanupResizeHandlers: (() => void) | undefined
     extWindow?.addEventListener('DOMContentLoaded', () => {
       const curWindow =
         BrowserWindow.getAllWindows().find((a) =>
@@ -280,30 +318,85 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
         height: Math.round(getYOffset() * latestZoom.current),
       })
 
-      extWindow?.addEventListener(
-        'resize',
-        debounce(() => {
-          // setAspectRatio above already constrains native resizes on Windows.
-          // Electron 41.2.1+ can subtract the frameless thick-frame insets when
-          // setContentSize is called, so feeding innerWidth back into it starts a
-          // resize loop that repeatedly shrinks the window at high DPI.
-          // https://github.com/electron/electron/issues/51679
-          if (process.platform === 'linux') {
-            curWindow?.setContentSize(
-              Math.round(extWindow.innerWidth * latestZoom.current),
-              Math.round(((extWindow.innerWidth / 1200) * 720 + getYOffset()) * latestZoom.current),
+      // `will-resize` is emitted only for manual resizes. Programmatic
+      // setContentSize calls do not reopen this gate, which prevents the
+      // frameless Windows inset from feeding a resize back into itself.
+      // https://github.com/electron/electron/issues/51679
+      const handleWillResize = () => {
+        windowsResizeCorrectionRef.current = null
+        windowsManualResizePendingRef.current = true
+        expireWindowsResizeState()
+      }
+      if (process.platform === 'win32') {
+        curWindow?.on('will-resize', handleWillResize)
+      }
+
+      const handleResize = debounce(() => {
+        if (process.platform === 'linux') {
+          const target = calculateKangameContentSize(
+            extWindow!.innerWidth,
+            latestZoom.current,
+            getYOffset(),
+          )
+          curWindow?.setContentSize(target.width, target.height)
+        } else if (process.platform === 'win32' && curWindow && extWindow) {
+          if (windowsManualResizePendingRef.current) {
+            const target = calculateKangameContentSize(
+              extWindow.innerWidth,
+              latestZoom.current,
+              getYOffset(),
             )
-          }
-          getStore('layout.webview.ref')?.executeJavaScript('window.align()')
-          const wv = extWindow.document.querySelector('webview')
-          if (wv) {
-            const { width: wvWidth, height: wvHeight } = wv.getBoundingClientRect()
-            dispatch(
-              createLayoutWebviewSizeAction({ windowWidth: wvWidth, windowHeight: wvHeight }),
+            windowsManualResizePendingRef.current = false
+            windowsResizeCorrectionRef.current = {
+              attempts: 0,
+              requested: target,
+              target,
+            }
+            curWindow.setContentSize(target.width, target.height)
+            expireWindowsResizeState()
+          } else if (windowsResizeCorrectionRef.current) {
+            // Keep the original manual-resize target immutable. Electron may
+            // subtract a DPI-scaled frame inset from the resulting viewport,
+            // so compensate the measured error without turning that smaller
+            // viewport into the next target. The retry cap guarantees that an
+            // unexpected platform response can never recreate the old loop.
+            const correction = windowsResizeCorrectionRef.current
+            const actual = {
+              width: Math.round(extWindow.innerWidth * latestZoom.current),
+              height: Math.round(extWindow.innerHeight * latestZoom.current),
+            }
+            const compensated = calculateCompensatedContentSize(
+              correction.target,
+              actual,
+              correction.requested,
             )
+            if (!compensated || correction.attempts >= WINDOWS_RESIZE_CORRECTION_LIMIT) {
+              clearWindowsResizeState()
+            } else {
+              windowsResizeCorrectionRef.current = {
+                ...correction,
+                attempts: correction.attempts + 1,
+                requested: compensated,
+              }
+              curWindow.setContentSize(compensated.width, compensated.height)
+              expireWindowsResizeState()
+            }
           }
-        }, 200),
-      )
+        }
+        getStore('layout.webview.ref')?.executeJavaScript('window.align()')
+        const wv = extWindow?.document.querySelector('webview')
+        if (wv) {
+          const { width: wvWidth, height: wvHeight } = wv.getBoundingClientRect()
+          dispatch(createLayoutWebviewSizeAction({ windowWidth: wvWidth, windowHeight: wvHeight }))
+        }
+      }, 200)
+
+      extWindow?.addEventListener('resize', handleResize)
+      cleanupResizeHandlers = () => {
+        curWindow?.off('will-resize', handleWillResize)
+        extWindow.removeEventListener('resize', handleResize)
+        handleResize.cancel()
+      }
 
       extWindow!.document.head.innerHTML = `<meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="script-src https://www.google-analytics.com 'self' file://* 'unsafe-inline'">
@@ -366,6 +459,8 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
     })
 
     return () => {
+      clearWindowsResizeState()
+      cleanupResizeHandlers?.()
       unwatchBoundsRef.current?.()
       unwatchBoundsRef.current = undefined
       try {
@@ -394,6 +489,7 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
   // Effect: apply windowUseFixedResolution changes after window is open
   useEffect(() => {
     if (!loaded || !currentWindowRef.current) return
+    clearWindowsResizeState()
     currentWindowRef.current.setResizable(!windowUseFixedResolution)
     if (windowUseFixedResolution) {
       const w = latestWindowWidth.current
@@ -403,16 +499,17 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
       )
     }
     dispatch(createLayoutWebviewWindowUseFixedResolutionAction(windowUseFixedResolution))
-  }, [windowUseFixedResolution, loaded, getYOffset])
+  }, [windowUseFixedResolution, loaded, getYOffset, clearWindowsResizeState])
 
   // Effect: apply windowWidth changes after window is open
   useEffect(() => {
     if (!loaded || !currentWindowRef.current) return
+    clearWindowsResizeState()
     currentWindowRef.current.setContentSize(
       windowWidth,
       Math.round((windowWidth / 1200) * 720 + getYOffset() * latestZoom.current),
     )
-  }, [windowWidth, loaded, getYOffset])
+  }, [windowWidth, loaded, getYOffset, clearWindowsResizeState])
 
   // eslint-disable-next-line react-hooks/refs
   if (!loaded || !externalWindowRef.current || !checkBrowserWindowExistence()) return null

--- a/views/kan-game-window-wrapper.tsx
+++ b/views/kan-game-window-wrapper.tsx
@@ -313,10 +313,15 @@ const KanGameWindowWrapperInner = ({ titleExtra, pinned, windowRefsRef }: InnerP
       )
       curWindow?.setClosable(false)
       curWindow?.setResizable(!initialWindowUseFixedResolution)
-      curWindow?.setAspectRatio(1200 / 720, {
-        width: 0,
-        height: Math.round(getYOffset() * latestZoom.current),
-      })
+      // Windows frameless thick-frame windows have DPI-dependent native insets
+      // that make Electron's aspect-ratio constraint visually inaccurate while
+      // dragging. Linux already uses the explicit resize correction below.
+      if (process.platform === 'darwin') {
+        curWindow?.setAspectRatio(1200 / 720, {
+          width: 0,
+          height: Math.round(getYOffset() * latestZoom.current),
+        })
+      }
 
       // `will-resize` is emitted only for manual resizes. Programmatic
       // setContentSize calls do not reopen this gate, which prevents the

--- a/views/utils/kangame-window-size.spec.ts
+++ b/views/utils/kangame-window-size.spec.ts
@@ -1,0 +1,37 @@
+import { calculateCompensatedContentSize, calculateKangameContentSize } from './kangame-window-size'
+
+describe('kangame window sizing', () => {
+  it('includes the titlebar offset in the desired content size', () => {
+    expect(calculateKangameContentSize(1200, 1, 60)).toEqual({
+      width: 1200,
+      height: 780,
+    })
+  })
+
+  it('applies the renderer zoom to the full content size', () => {
+    expect(calculateKangameContentSize(600, 2, 60)).toEqual({
+      width: 1200,
+      height: 840,
+    })
+  })
+
+  it('compensates from the fixed target instead of shrinking it', () => {
+    expect(
+      calculateCompensatedContentSize(
+        { width: 1200, height: 780 },
+        { width: 1184, height: 772 },
+        { width: 1200, height: 780 },
+      ),
+    ).toEqual({ width: 1216, height: 788 })
+  })
+
+  it('stops when the measured size is within one DIP of the target', () => {
+    expect(
+      calculateCompensatedContentSize(
+        { width: 1200, height: 780 },
+        { width: 1199, height: 781 },
+        { width: 1216, height: 788 },
+      ),
+    ).toBeNull()
+  })
+})

--- a/views/utils/kangame-window-size.ts
+++ b/views/utils/kangame-window-size.ts
@@ -1,0 +1,33 @@
+export interface ContentSize {
+  width: number
+  height: number
+}
+
+const KANGAME_WIDTH = 1200
+const KANGAME_HEIGHT = 720
+
+export const calculateKangameContentSize = (
+  innerWidth: number,
+  zoom: number,
+  yOffset: number,
+): ContentSize => ({
+  width: Math.round(innerWidth * zoom),
+  height: Math.round(((innerWidth / KANGAME_WIDTH) * KANGAME_HEIGHT + yOffset) * zoom),
+})
+
+export const calculateCompensatedContentSize = (
+  target: ContentSize,
+  actual: ContentSize,
+  requested: ContentSize,
+  tolerance = 1,
+): ContentSize | null => {
+  const widthError = target.width - actual.width
+  const heightError = target.height - actual.height
+  if (Math.abs(widthError) <= tolerance && Math.abs(heightError) <= tolerance) {
+    return null
+  }
+  return {
+    width: Math.max(1, requested.width + widthError),
+    height: Math.max(1, requested.height + heightError),
+  }
+}


### PR DESCRIPTION
## Summary

- avoid feeding the renderer viewport width back into BrowserWindow.setContentSize on Windows
- rely on the existing native aspect-ratio constraint on Windows while preserving the Linux correction
- prevent the Electron frameless thick-frame resize inset from causing a high-DPI shrink loop

Fixes #2708

## Testing

- npx eslint views/kan-game-window-wrapper.tsx
- pre-commit ESLint and stylelint checks
- git diff --check
- npm run typecheck (blocked by the existing Clipboard.writeImage type error in views/components/info/control.tsx)