### PR TITLE
fix: correct combined fleet Saku33 calculation

### DIFF
--- a/views/components/ship-parts/fleet-stat.tsx
+++ b/views/components/ship-parts/fleet-stat.tsx
@@ -20,7 +20,13 @@ import { getStore } from 'views/create-store'
 import { ROOT } from 'views/env'
 import i18next from 'views/env-parts/i18next'
 import { recoveryEndTime } from 'views/redux/timers/cond'
-import { getFleetSpeed, getSaku33, getSpeedLabel, getTyku } from 'views/utils/game-utils'
+import {
+  getFleetSpeed,
+  getSaku33,
+  getCombinedSaku33,
+  getSpeedLabel,
+  getTyku,
+} from 'views/utils/game-utils'
 import { CountdownNotifier } from 'views/utils/notifiers'
 import {
   basicSelector,
@@ -261,15 +267,47 @@ const combinedSakuSelector = createSelector(
     mainSlotCount,
     escortSlotCount,
   ) => {
-    const shipsData = [...mainShips, ...escortShips]
-    const equipsData = [...mainEquips, ...escortEquips]
-    // the admiral term is subtracted once, empty slots are counted over both fleets
-    const slotCount = mainSlotCount + escortSlotCount
     return {
-      saku33: getSaku33(shipsData, equipsData, admiralLevel, 1.0, slotCount),
-      saku33x2: getSaku33(shipsData, equipsData, admiralLevel, 2.0, slotCount),
-      saku33x3: getSaku33(shipsData, equipsData, admiralLevel, 3.0, slotCount),
-      saku33x4: getSaku33(shipsData, equipsData, admiralLevel, 4.0, slotCount),
+      saku33: getCombinedSaku33(
+        mainShips,
+        mainEquips,
+        escortShips,
+        escortEquips,
+        admiralLevel,
+        1.0,
+        mainSlotCount,
+        escortSlotCount,
+      ),
+      saku33x2: getCombinedSaku33(
+        mainShips,
+        mainEquips,
+        escortShips,
+        escortEquips,
+        admiralLevel,
+        2.0,
+        mainSlotCount,
+        escortSlotCount,
+      ),
+      saku33x3: getCombinedSaku33(
+        mainShips,
+        mainEquips,
+        escortShips,
+        escortEquips,
+        admiralLevel,
+        3.0,
+        mainSlotCount,
+        escortSlotCount,
+      ),
+      saku33x4: getCombinedSaku33(
+        mainShips,
+        mainEquips,
+        escortShips,
+        escortEquips,
+        admiralLevel,
+        4.0,
+        mainSlotCount,
+        escortSlotCount,
+      ),
     }
   },
 )

--- a/views/utils/game-utils.ts
+++ b/views/utils/game-utils.ts
@@ -720,7 +720,7 @@ export function getSaku33(
           equipSaku += $equip.api_saku * 0.8
           break
         case 9:
-          equipSaku += $equip.api_saku * 1.0
+          equipSaku += ($equip.api_saku + 1.2 * Math.sqrt(_equip.api_level || 0)) * 1.0
           break
         case 10:
           equipSaku += ($equip.api_saku + 1.2 * Math.sqrt(_equip.api_level || 0)) * 1.2
@@ -732,7 +732,13 @@ export function getSaku33(
           equipSaku += ($equip.api_saku + 1.25 * Math.sqrt(_equip.api_level || 0)) * 0.6
           break
         case 13:
-          equipSaku += ($equip.api_saku + 1.25 * Math.sqrt(_equip.api_level || 0)) * 0.6
+          equipSaku += ($equip.api_saku + 1.4 * Math.sqrt(_equip.api_level || 0)) * 0.6
+          break
+        case 26:
+          equipSaku += ($equip.api_saku + 1.0 * Math.sqrt(_equip.api_level || 0)) * 0.6
+          break
+        case 41:
+          equipSaku += ($equip.api_saku + 1.2 * Math.sqrt(_equip.api_level || 0)) * 0.6
           break
         default:
           equipSaku += $equip.api_saku * 0.6
@@ -750,6 +756,32 @@ export function getSaku33(
     item: parseFloat(equipSaku.toFixed(2)),
     teitoku: parseFloat(teitokuSaku.toFixed(2)),
     total: parseFloat(totalSaku.toFixed(2)),
+  }
+}
+
+export function getCombinedSaku33(
+  mainShipsData: [APIShip, APIMstShip][],
+  mainEquipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
+  escortShipsData: [APIShip, APIMstShip][],
+  escortEquipsData: ([Equip, APIMstSlotitem, number | undefined] | undefined)[][],
+  teitokuLv: number,
+  mapModifier: number | undefined,
+  mainSlotCount = 6,
+  escortSlotCount = 6,
+) {
+  const mainSaku33 = getSaku33(mainShipsData, mainEquipsData, teitokuLv, mapModifier, mainSlotCount)
+  const escortSaku33 = getSaku33(
+    escortShipsData,
+    escortEquipsData,
+    teitokuLv,
+    mapModifier,
+    escortSlotCount,
+  )
+  return {
+    ship: mainSaku33.ship + escortSaku33.ship,
+    item: mainSaku33.item + escortSaku33.item,
+    teitoku: mainSaku33.teitoku + escortSaku33.teitoku,
+    total: mainSaku33.total + escortSaku33.total,
   }
 }
 


### PR DESCRIPTION
现在的poi版本将主队和随伴舰队合并成一个12船舰队去计算索敌，根据 [wikiwiki](https://wikiwiki.jp/kancolle/%E3%83%AB%E3%83%BC%E3%83%88%E5%88%86%E5%B2%90) 相关条目的描述，应当先分别计算主队和随伴舰队的索敌再相加，当前会使司令部等级补正被少算一次，导致算出的索敌值虚高。~~还特地注释了一下~~
另外，当前的版本中缺少部分装备的改修索敌系数加成（大艇和对潜哨戒机），大型电探根据 wikiwiki 的改修系数是 1.4，舰侦是 1.2。