### PR TITLE
fix: missing map rank text

### DIFF
--- a/views/components/info/map-reminder.tsx
+++ b/views/components/info/map-reminder.tsx
@@ -302,7 +302,7 @@ const mapReminderSelector = createSelector(
 
 export const PoiMapReminder = () => {
   const { t } = useTranslation()
-  const { mapHp, mapData, nextEnemy, currentNode, mapId, maps, pinminimap } = useSelector(
+  const { mapHp, mapData, nextEnemy, currentNode, mapId, maps, pinminimap, rank } = useSelector(
     (state: RootState) => mapReminderSelector(state),
   )
 
@@ -400,7 +400,7 @@ export const PoiMapReminder = () => {
           )}
           <Alert>
             <span id="map-reminder-area">
-              {getMapText(mapData, ['', t('丁'), t('丙'), t('乙'), t('甲')], undefined)}
+              {getMapText(mapData, ['', t('丁'), t('丙'), t('乙'), t('甲')], rank)}
             </span>
           </Alert>
         </MapReminder>


### PR DESCRIPTION
getMapText() 需要传入地图难度数据来显示字样，但是现版本传了个 undefined 进去，导致无法正确显示难度。