### PR TITLE
fix(control): hold the toolbar popup's action instead of its pointer events

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -93,18 +93,6 @@ poi-main {
   transition: transform 100ms cubic-bezier(0.4, 1, 0.75, 0.9);
 }
 
-/* Mid-slide the popup lies over the button it came from, so a click landing in
-   that window would fire the alternate action instead of the primary one. Let
-   it through until the popup has settled. */
-.poi-control-alt-portal .bp6-popover-appear .bp6-popover,
-.poi-control-alt-portal .bp6-popover-appear-active .bp6-popover,
-.poi-control-alt-portal .bp6-popover-enter .bp6-popover,
-.poi-control-alt-portal .bp6-popover-enter-active .bp6-popover,
-.poi-control-alt-portal .bp6-popover-exit .bp6-popover,
-.poi-control-alt-portal .bp6-popover-exit-active .bp6-popover {
-  pointer-events: none;
-}
-
 .bp6-html-select select,
 .bp6-select select {
   background-image: none;

--- a/views/components/info/control.tsx
+++ b/views/components/info/control.tsx
@@ -130,11 +130,30 @@ const ControlButton = ({
   onLabel: (column: string, text: string) => void
   onLabelEnd: () => void
 }) => {
+  // While it slides, the popup lies over the button it came from, so a click
+  // landing in that window would fire the alternate action when the primary
+  // one was aimed at (or the reverse on the way out). Ignore clicks until it
+  // settles -- blanking the popup's pointer events instead would also blank
+  // the hover tracking that keeps it open and hands the label over.
+  const settledAtRef = useRef(0)
+
+  const handleAlternateClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (Date.now() < settledAtRef.current) return
+      onContextMenu?.(event)
+    },
+    [onContextMenu],
+  )
+
+  const holdClicks = useCallback(() => {
+    settledAtRef.current = Date.now() + TRANSITION_DURATION
+  }, [])
+
   const alternate = onContextMenu && altIcon && (
     <Button
       aria-label={altLabel ?? label}
       icon={<AlternateIcon icon={icon} badge={altIcon} />}
-      onClick={onContextMenu}
+      onClick={handleAlternateClick}
       onMouseEnter={() => onLabel(label, altLabel ?? label)}
       onMouseLeave={onLabelEnd}
       onFocus={() => onLabel(label, altLabel ?? label)}
@@ -170,6 +189,8 @@ const ControlButton = ({
         // the outgoing popup has to be gone before the next column's opens,
         // otherwise two alternate buttons are on screen at once
         transitionDuration={TRANSITION_DURATION}
+        onOpening={holdClicks}
+        onClosing={holdClicks}
       >
         <Button
           aria-label={label}


### PR DESCRIPTION
Follow-up to #2715, fixing a regression its second commit introduced.

## The problem

`2e2e01fe` disabled pointer events on the alternate popup for the whole of its 100 ms slide, so a click landing mid-slide would fall through to the main button instead of firing the alternate action. That guard was too broad — hit-testing is also how the popup is kept alive:

- **The popup closes as it settles.** Blueprint cancels a pending close when the pointer enters the popover content. With pointer events off it never sees that, and `hoverCloseDelay={0}` means the close scheduled by leaving the button goes through — so moving up onto the popup promptly, the core gesture of the feature, loses it.
- **The tooltip label never hands over.** The alternate button's `onMouseEnter` can't fire during the slide, so the label stays on the base action and then closes while the popup is still hovered.
- **The misdirection was inverted, not removed.** The popup is visible and covers the button while sliding, so a click aimed at the popup fired the *primary* action — on the Refresh game column, the confirmation dialog instead of the reload.

## The fix

Gate the action rather than the hit-testing, as the review suggested. `onOpening`/`onClosing` stamp a deadline `TRANSITION_DURATION` ahead, and the alternate button's `onClick` returns early before it. Pointer events stay live, so hover tracking, close-cancelling and the label handover all work; a click inside either transition window does nothing rather than the wrong thing.

Found by the automated review on #2715 after it had been merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
