### PR TITLE
fix(ci): publish artifacts after partial build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         buildType: [x64, arm64]
     steps:
@@ -34,6 +35,7 @@ jobs:
   macos:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         buildType: [x64, arm64]
     steps:
@@ -66,6 +68,8 @@ jobs:
   upload-to-r2:
     name: Upload to Cloudflare R2
     needs: [linux, macos, windows]
+    # A failed matrix job can still have successful builds with uploaded artifacts.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -74,8 +78,13 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: List artifacts
-        run: ls -lh artifacts/
+      - name: Check and list build artifacts
+        run: |
+          if [[ ! -d artifacts ]] || [[ -z "$(find artifacts -type f -print -quit)" ]]; then
+            echo "No successful build artifacts to publish."
+            exit 1
+          fi
+          ls -lh artifacts/
 
       - name: Generate SHA256 checksums
         working-directory: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
   create-release:
     name: Create GitHub Release
     needs: [linux, macos, windows]
+    # Publish successful platforms even if another platform failed to build.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -75,6 +77,13 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Check for build artifacts
+        run: |
+          if [[ ! -d artifacts ]] || [[ -z "$(find artifacts -type f -print -quit)" ]]; then
+            echo "No successful build artifacts to publish."
+            exit 1
+          fi
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,15 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          BUILD_STATUS: |
+            Initial build results: Linux — ${{ needs.linux.result }}, macOS — ${{ needs.macos.result }}, Windows — ${{ needs.windows.result }}.
+
+            Artifacts from successful builds are published independently; reruns may add remaining platform artifacts.
+            [Build details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           gh release create ${{ github.ref_name }} \
             --title "${{ github.ref_name }}" \
             --generate-notes \
+            --notes "$BUILD_STATUS" \
             artifacts/* || \
           gh release upload ${{ github.ref_name }} artifacts/* --clobber


### PR DESCRIPTION
A macOS arm64 failure currently cancels the sibling x64 build and skips R2 publication even when Linux and Windows artifacts are available (for example, https://github.com/poooi/poi/actions/runs/34310833632).

Disable fail-fast for the multi-entry Linux/macOS CI matrices. Allow the nightly R2 and tagged GitHub Release publishing jobs to run after failed dependencies unless the workflow is cancelled. Decide whether to publish from the downloaded artifacts, so a failed matrix group can still contribute successful child builds; reject missing or empty artifacts before any publishing step. Build failures remain visible in the workflow result. Newly created release notes include the initial Linux/macOS/Windows build results and a link to the workflow, so a partial initial publication is disclosed. These historical results remain accurate if reruns later add assets.

Validation:
- actionlint 1.7.12 passes for both changed workflows (ShellCheck/Pyflakes integrations disabled).
- Local publisher-condition checks cover successful builds, partial failures, all matrix groups failed, and workflow cancellation.
- Executed both workflows' artifact guards in Bash against missing, empty, single-platform, and multiple-platform artifact fixtures: all 8 cases pass.
- Simulated gh execution of the actual release script passes for complete builds, partial builds, and existing-release reruns; the multiline build-status note is preserved and upload fallback remains intact.
- npm run typecheck and git diff --check pass.

Full multi-platform builds and real R2/GitHub Release publication have not been exercised locally.

